### PR TITLE
[BUG] Optimize reserve slots, make first time reserve action in parallel

### DIFF
--- a/client/src/main/java/com/aliyun/emr/rss/client/ShuffleClientImpl.java
+++ b/client/src/main/java/com/aliyun/emr/rss/client/ShuffleClientImpl.java
@@ -30,7 +30,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import com.aliyun.emr.rss.common.util.RpcUtils;
 import scala.reflect.ClassTag;
 import scala.reflect.ClassTag$;
 
@@ -75,6 +74,7 @@ import com.aliyun.emr.rss.common.rpc.RpcAddress;
 import com.aliyun.emr.rss.common.rpc.RpcEndpointRef;
 import com.aliyun.emr.rss.common.rpc.RpcEnv;
 import com.aliyun.emr.rss.common.unsafe.Platform;
+import com.aliyun.emr.rss.common.util.RpcUtils;
 import com.aliyun.emr.rss.common.util.ThreadUtils;
 import com.aliyun.emr.rss.common.util.Utils;
 

--- a/client/src/main/java/com/aliyun/emr/rss/client/write/LifecycleManager.scala
+++ b/client/src/main/java/com/aliyun/emr/rss/client/write/LifecycleManager.scala
@@ -586,8 +586,8 @@ class LifecycleManager(appId: String, val conf: RssConf) extends RpcEndpoint wit
     val allocatedWorkers = shuffleAllocatedWorkers.get(shuffleId)
     val commitFilesFailedWorkers = new ConcurrentSet[WorkerInfo]
 
-    val parallelism = Math.min(workerSnapshots(shuffleId).size(),
-      RssConf.rpcMaxParallelism(conf))
+    val parallelism = Array(workerSnapshots(shuffleId).size(),
+      RssConf.rpcMaxParallelism(conf), Runtime.getRuntime().availableProcessors()).min
     ThreadUtils.parmap(
       allocatedWorkers.asScala.to, "CommitFiles", parallelism) { w2p =>
       val worker = w2p._1

--- a/client/src/main/java/com/aliyun/emr/rss/client/write/LifecycleManager.scala
+++ b/client/src/main/java/com/aliyun/emr/rss/client/write/LifecycleManager.scala
@@ -28,15 +28,17 @@ import com.aliyun.emr.rss.common.protocol.{PartitionLocation, RpcNameConstants}
 import com.aliyun.emr.rss.common.rpc._
 import com.aliyun.emr.rss.common.rpc.netty.{NettyRpcEndpointRef, NettyRpcEnv}
 import com.aliyun.emr.rss.common.util.{RpcUtils, ThreadUtils, Utils}
-import io.netty.util.internal.ConcurrentSet
 
 import java.io.IOException
 import java.util
 import java.util.concurrent.{ConcurrentHashMap, ScheduledFuture, TimeUnit}
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.util.Random
+
+import io.netty.util.internal.ConcurrentSet
 
 class LifecycleManager(appId: String, val conf: RssConf) extends RpcEndpoint with Logging {
 

--- a/client/src/test/java/com/aliyun/emr/rss/client/ShuffleClientSuiteJ.java
+++ b/client/src/test/java/com/aliyun/emr/rss/client/ShuffleClientSuiteJ.java
@@ -149,8 +149,8 @@ public class ShuffleClientSuiteJ {
       eq(ClassTag$.MODULE$.apply(ControlMessages.RegisterShuffleResponse.class))))
       .thenAnswer(t -> new ControlMessages.RegisterShuffleResponse(StatusCode.Success,
         new ArrayList<PartitionLocation>() {{
-          add(masterLocation);
-        }}));
+            add(masterLocation);
+          }}));
 
     shuffleClient.setupMetaServiceRef(endpointRef);
 

--- a/client/src/test/java/com/aliyun/emr/rss/client/ShuffleClientSuiteJ.java
+++ b/client/src/test/java/com/aliyun/emr/rss/client/ShuffleClientSuiteJ.java
@@ -34,7 +34,8 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Test;
-import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -141,13 +142,15 @@ public class ShuffleClientSuiteJ {
     shuffleClient = new ShuffleClientImpl(conf);
 
     masterLocation.setPeer(slaveLocation);
-    when(endpointRef.askSync(new ControlMessages.RegisterShuffle(TEST_APPLICATION_ID,
-        TEST_SHUFFLE_ID, 1, 1),
-      ClassTag$.MODULE$.apply(ControlMessages.RegisterShuffleResponse.class)))
+
+    when(endpointRef.askSync(
+      eq(new ControlMessages.RegisterShuffle(TEST_APPLICATION_ID, TEST_SHUFFLE_ID, 1, 1)),
+      any(),
+      eq(ClassTag$.MODULE$.apply(ControlMessages.RegisterShuffleResponse.class))))
       .thenAnswer(t -> new ControlMessages.RegisterShuffleResponse(StatusCode.Success,
         new ArrayList<PartitionLocation>() {{
-            add(masterLocation);
-          }}));
+          add(masterLocation);
+        }}));
 
     shuffleClient.setupMetaServiceRef(endpointRef);
 

--- a/common/src/main/java/com/aliyun/emr/rss/common/haclient/RssHARetryClient.java
+++ b/common/src/main/java/com/aliyun/emr/rss/common/haclient/RssHARetryClient.java
@@ -129,7 +129,8 @@ public class RssHARetryClient {
   }
 
   @SuppressWarnings("UnstableApiUsage")
-  private <T> T sendMessageInner(Message message, Class<T> clz, RpcTimeout timeout) throws Throwable {
+  private <T> T sendMessageInner(Message message, Class<T> clz,
+      RpcTimeout timeout) throws Throwable {
     Throwable throwable = null;
     int numTries = 0;
     boolean shouldRetry = true;

--- a/common/src/main/scala/com/aliyun/emr/rss/common/RssConf.scala
+++ b/common/src/main/scala/com/aliyun/emr/rss/common/RssConf.scala
@@ -547,10 +547,6 @@ object RssConf extends Logging {
     conf.getInt("rss.worker.base.dir.number", 16)
   }
 
-  def stageEndTimeout(conf: RssConf): Long = {
-    conf.getTimeAsMs("rss.stage.end.timeout", "240s")
-  }
-
   def limitInFlightTimeoutMs(conf: RssConf): Long = {
     conf.getTimeAsMs("rss.limit.inflight.timeout", "240s")
   }

--- a/common/src/main/scala/com/aliyun/emr/rss/common/util/RpcUtils.scala
+++ b/common/src/main/scala/com/aliyun/emr/rss/common/util/RpcUtils.scala
@@ -62,9 +62,19 @@ private[rss] object RpcUtils {
     RpcTimeout(conf, "rss.getReducerFileGroup.timeout", "240s")
   }
 
+  /** Returns the master RequestSlots timeout to use for RPC ask operations. */
+  def requestSlotsRpcTimeout(conf: RssConf): RpcTimeout = {
+    RpcTimeout(conf, "rss.requestSlots.timeout", "30s")
+  }
+
   /** Returns the driver ReserveSlots timeout to use for RPC ask operations. */
   def reserveSlotsRpcTimeout(conf: RssConf): RpcTimeout = {
     RpcTimeout(conf, "rss.reserveSlots.timeout", "30s")
+  }
+
+  /** Returns the master RequestSlots timeout to use for RPC ask operations. */
+  def releaseSlotsRpcTimeout(conf: RssConf): RpcTimeout = {
+    RpcTimeout(conf, "rss.releaseSlots.timeout", "30s")
   }
 
   /** Returns the driver destroy timeout to use for RPC ask operations. */
@@ -80,6 +90,11 @@ private[rss] object RpcUtils {
   /** Returns the master applicationLost timeout to use for RPC ask operations. */
   def applicationLostRpcTimeout(conf: RssConf): RpcTimeout = {
     RpcTimeout(conf, "rss.applicationLost.timeout", "120s")
+  }
+
+  /** Returns the master GetClusterLoadStatus timeout to use for RPC ask operations. */
+  def getClusterLoadStatusTimeout(conf: RssConf): RpcTimeout = {
+    RpcTimeout(conf, "rss.getClusterLoadStatus.timeout", "30s")
   }
 
   private val MAX_MESSAGE_SIZE_IN_MB = Int.MaxValue / 1024 / 1024

--- a/common/src/main/scala/com/aliyun/emr/rss/common/util/RpcUtils.scala
+++ b/common/src/main/scala/com/aliyun/emr/rss/common/util/RpcUtils.scala
@@ -34,14 +34,52 @@ private[rss] object RpcUtils {
 
   /** Returns the default Spark timeout to use for RPC ask operations. */
   def askRpcTimeout(conf: RssConf): RpcTimeout = {
-    RpcTimeout(conf, Seq("rss.rpc.askTimeout",
-      "rss.network.timeout"), "240s")
+    RpcTimeout(conf, "rss.network.timeout", "240s")
   }
 
   /** Returns the default Spark timeout to use for RPC remote endpoint lookup. */
   def lookupRpcTimeout(conf: RssConf): RpcTimeout = {
-    RpcTimeout(conf, Seq("rss.rpc.lookupTimeout",
-      "rss.network.timeout"), "240s")
+    RpcTimeout(conf, "rss.rpc.lookupTimeout", "60s")
+  }
+
+  /** Returns the executor register shuffle timeout to use for RPC ask operations. */
+  def registerShuffleRpcTimeout(conf: RssConf): RpcTimeout = {
+    RpcTimeout(conf, "rss.registerShuffle.timeout", "240s")
+  }
+
+  /** Returns the executor revive timeout to use for RPC ask operations. */
+  def reviveRpcTimeout(conf: RssConf): RpcTimeout = {
+    RpcTimeout(conf, "rss.revive.timeout", "240s")
+  }
+
+  /** Returns the executor mapperEnd timeout to use for RPC ask operations. */
+  def mapperEndRpcTimeout(conf: RssConf): RpcTimeout = {
+    RpcTimeout(conf, "rss.mapperEnd.timeout", "240s")
+  }
+
+  /** Returns the executor getReducerFileGroup timeout to use for RPC ask operations. */
+  def getReducerFileGroupResponseRpcTimeout(conf: RssConf): RpcTimeout = {
+    RpcTimeout(conf, "rss.getReducerFileGroup.timeout", "240s")
+  }
+
+  /** Returns the driver ReserveSlots timeout to use for RPC ask operations. */
+  def reserveSlotsRpcTimeout(conf: RssConf): RpcTimeout = {
+    RpcTimeout(conf, "rss.reserveSlots.timeout", "30s")
+  }
+
+  /** Returns the driver destroy timeout to use for RPC ask operations. */
+  def destroyRpcTimeout(conf: RssConf): RpcTimeout = {
+    RpcTimeout(conf, "rss.destroy.timeout", "30s")
+  }
+
+  /** Returns the driver commitFiles timeout to use for RPC ask operations. */
+  def commitFilesRpcTimeout(conf: RssConf): RpcTimeout = {
+    RpcTimeout(conf, "rss.commitFiles.timeout", "60s")
+  }
+
+  /** Returns the master applicationLost timeout to use for RPC ask operations. */
+  def applicationLostRpcTimeout(conf: RssConf): RpcTimeout = {
+    RpcTimeout(conf, "rss.applicationLost.timeout", "120s")
   }
 
   private val MAX_MESSAGE_SIZE_IN_MB = Int.MaxValue / 1024 / 1024

--- a/common/src/test/java/com/aliyun/emr/rss/common/haclient/RssHARetryClientSuiteJ.java
+++ b/common/src/test/java/com/aliyun/emr/rss/common/haclient/RssHARetryClientSuiteJ.java
@@ -59,8 +59,7 @@ public class RssHARetryClientSuiteJ {
 
   @Before
   public void beforeEach() {
-    rssConf.set("rss.rpc.askTimeout", "5s")
-      .set("rss.network.timeout", "5s")
+    rssConf.set("rss.network.timeout", "5s")
       .set("rss.master.port", String.valueOf(masterPort));
     rpcEnv = Mockito.mock(RpcEnv.class);
     endpointRef = Mockito.mock(RpcEndpointRef.class);

--- a/server-master/src/main/scala/com/aliyun/emr/rss/service/deploy/master/Master.scala
+++ b/server-master/src/main/scala/com/aliyun/emr/rss/service/deploy/master/Master.scala
@@ -19,9 +19,11 @@ package com.aliyun.emr.rss.service.deploy.master
 
 import java.util
 import java.util.concurrent.{ScheduledFuture, TimeUnit}
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.Random
+
 import com.aliyun.emr.rss.common.RssConf
 import com.aliyun.emr.rss.common.RssConf.haEnabled
 import com.aliyun.emr.rss.common.haclient.RssHARetryClient


### PR DESCRIPTION
# [BUG] Optimize reserve slots, make first reserve action in parallel

### What changes were proposed in this pull request?
Make first reserve slots action in parallel

### Why are the changes needed?
Current logic, we reserve slots in serial, if cluster have hundreds and thousands workers, the action will take long time, it will cause register shuffle timeout.

### What are the items that need reviewer attention?
I just make it in parallel at first time, because i think retry will retry with only a few workers

### Related issues.
#52 

### How was this patch tested?
current ut

