### PR TITLE
[ISSUE-136] Disable high load worker

### DIFF
--- a/common/src/main/scala/com/aliyun/emr/rss/common/RssConf.scala
+++ b/common/src/main/scala/com/aliyun/emr/rss/common/RssConf.scala
@@ -697,7 +697,7 @@ object RssConf extends Logging {
    * @return the threshold value of system load
    */
   def workerSystemLoadThreshold(conf: RssConf): Double = {
-    conf.getDouble("rss.worker.systemLoad.threshold", 0.9)
+    conf.getDouble("rss.worker.systemLoad.threshold", 0.95)
   }
 
   def workerStatusCheckTimeout(conf: RssConf): Long = {

--- a/common/src/main/scala/com/aliyun/emr/rss/common/RssConf.scala
+++ b/common/src/main/scala/com/aliyun/emr/rss/common/RssConf.scala
@@ -17,6 +17,7 @@
 
 package com.aliyun.emr.rss.common
 
+import java.lang.management.ManagementFactory
 import java.util.{Map => JMap}
 import java.util.concurrent.ConcurrentHashMap
 
@@ -688,6 +689,15 @@ object RssConf extends Logging {
    */
   def diskSpaceSafeWatermarkSizeInGb(conf: RssConf): Long = {
     conf.getSizeAsGb("rss.disk.space.safe.watermark.size", "0GB")
+  }
+
+  /**
+   * Be aware that [rss.worker.systemLoad.threshold] should be value between (0, 1]
+   * @param conf rss config
+   * @return the threshold value of system load
+   */
+  def workerSystemLoadThreshold(conf: RssConf): Double = {
+    conf.getDouble("rss.worker.systemLoad.threshold", 0.9)
   }
 
   def workerStatusCheckTimeout(conf: RssConf): Long = {

--- a/server-worker/src/main/java/com/aliyun/emr/rss/service/deploy/worker/DeviceErrorType.java
+++ b/server-worker/src/main/java/com/aliyun/emr/rss/service/deploy/worker/DeviceErrorType.java
@@ -21,7 +21,8 @@ public enum DeviceErrorType {
   ReadOrWriteFailure(1),
   IoHang(2),
   InsufficientDiskSpace(3),
-  FlushTimeout(4);
+  FlushTimeout(4),
+  SystemHighLoad(5);
 
   private final byte value;
 
@@ -36,6 +37,7 @@ public enum DeviceErrorType {
 
   public static boolean criticalError(DeviceErrorType error) {
     return error.equals(DeviceErrorType.IoHang) ||
-            error.equals(DeviceErrorType.ReadOrWriteFailure);
+        error.equals(DeviceErrorType.ReadOrWriteFailure) ||
+        error.equals(DeviceErrorType.SystemHighLoad);
   }
 }

--- a/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/DeviceMonitor.scala
+++ b/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/DeviceMonitor.scala
@@ -189,7 +189,7 @@ class LocalDeviceMonitor(essConf: RssConf, observer: DeviceObserver,
         try {
           if (DeviceMonitor.checkSystemLoad(essConf)) {
             // When system high load, remove all working dirs.
-            observedDevices.values().forEach { device =>
+            observedDevices.values().asScala.foreach { device =>
               device.notifyObserversOnError(
                 device.mountInfos.flatMap(mount => mount.dirInfos),
                 DeviceErrorType.SystemHighLoad)

--- a/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/DeviceMonitor.scala
+++ b/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/DeviceMonitor.scala
@@ -17,7 +17,7 @@
 
 package com.aliyun.emr.rss.service.deploy.worker
 
-import java.io.{BufferedReader, File, FileInputStream, IOException, InputStreamReader}
+import java.io.{BufferedReader, File, FileInputStream, InputStreamReader, IOException}
 import java.lang.management.ManagementFactory
 import java.nio.charset.Charset
 import java.util
@@ -211,7 +211,9 @@ class LocalDeviceMonitor(essConf: RssConf, observer: DeviceObserver,
                     logger.error(s"${entry.mountPoint} read-write error, notify observers")
                     // We think that if one dir in device has read-write problem, if possible all
                     // dirs in this device have the problem
-                    device.notifyObserversOnError(entry.dirInfos, DeviceErrorType.ReadOrWriteFailure)
+                    device.notifyObserversOnError(
+                      entry.dirInfos,
+                      DeviceErrorType.ReadOrWriteFailure)
                   } else {
                     device.notifyObserversOnHealthy(entry.dirInfos)
                   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Disable high load worker.
When systemLoad > threshold, will disable all device, then worker slot will be 0, then will be in master's blacklist.
When systemLoad decreased and less than threshold, device will recover and numSlots will  > 0, then master will remove it from blacklist.

### Why are the changes needed?

When worker in high load, executor push data to worker will timeout.

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
