### PR TITLE
[ISSUE-635][FEATURE] Worker collect user level resource usage

### DIFF
--- a/common/src/main/scala/com/aliyun/emr/rss/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/com/aliyun/emr/rss/common/meta/WorkerInfo.scala
@@ -216,10 +216,12 @@ class WorkerInfo(
     }
   }
 
-  def updateUserResourceConsumption(consumption: util.Map[UserIdentifier, ResourceConsumption])
-      : Unit = {
+  def updateThenGetUserResourceConsumption(consumption: util.Map[
+    UserIdentifier,
+    ResourceConsumption]): util.Map[UserIdentifier, ResourceConsumption] = {
     userResourceConsumption.clear()
     userResourceConsumption.putAll(consumption)
+    userResourceConsumption
   }
 
   override def toString(): String = {

--- a/server-master/src/main/java/com/aliyun/emr/rss/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/server-master/src/main/java/com/aliyun/emr/rss/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -175,7 +175,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
       workerInfo.ifPresent(
           info -> {
             info.updateDiskInfos(disks, estimatedPartitionSize);
-            info.updateUserResourceConsumption(userResourceConsumption);
+            info.updateThenGetUserResourceConsumption(userResourceConsumption);
             availableSlots.set(info.totalAvailableSlots());
             info.lastHeartbeat_$eq(time);
           });
@@ -209,7 +209,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
     }
 
     workerInfo.updateDiskMaxSlots(estimatedPartitionSize);
-    workerInfo.updateUserResourceConsumption(userResourceConsumption);
+    workerInfo.updateThenGetUserResourceConsumption(userResourceConsumption);
     synchronized (workers) {
       workers.add(workerInfo);
     }

--- a/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/Worker.scala
+++ b/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/Worker.scala
@@ -217,7 +217,8 @@ private[deploy] class Worker(
         fetchPort,
         replicatePort,
         diskInfos,
-        workerInfo.userResourceConsumption,
+        workerInfo.updateThenGetUserResourceConsumption(
+          storageManager.userResourceConsumptionSnapshot().asJava),
         shuffleKeys),
       classOf[HeartbeatResponse])
     if (response.registered) {
@@ -335,7 +336,8 @@ private[deploy] class Worker(
               fetchPort,
               replicatePort,
               workerInfo.diskInfos.asScala.toMap,
-              workerInfo.userResourceConsumption.asScala.toMap,
+              workerInfo.updateThenGetUserResourceConsumption(
+                storageManager.userResourceConsumptionSnapshot().asJava).asScala.toMap,
               RssHARetryClient.genRequestId()),
             classOf[PbRegisterWorkerResponse])
         } catch {

--- a/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/storage/StorageManager.scala
+++ b/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/storage/StorageManager.scala
@@ -576,15 +576,11 @@ final private[worker] class StorageManager(conf: RssConf, workerSource: Abstract
     logInfo(s"Updated diskInfos: ${disksSnapshot()}")
   }
 
-  def getUserFileInfos(shuffleKey: String): Seq[FileInfo] = {
-    fileInfos.get(shuffleKey).values().asScala.toSeq
-  }
-
   def userResourceConsumptionSnapshot(): Map[UserIdentifier, ResourceConsumption] = {
     userShuffleKeys.synchronized {
       userShuffleKeys.asScala.map { case (userIdentifier, shuffleKeys) =>
         val resourceMetrics = shuffleKeys.asScala.map { shuffleKey =>
-          val userFileInfos = getUserFileInfos(shuffleKey)
+          val userFileInfos = fileInfos.get(shuffleKey).values().asScala.toSeq
           val diskFileInfos = userFileInfos.filter(!_.isHdfs)
           val hdfsFileInfos = userFileInfos.filter(_.isHdfs)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
 Worker collect user level resource usage

### Why are the changes needed?


### What are the items that need reviewer attention?
Because the StorageManager is limited to being called within the scope of worker, current implementation seems not feel elegant (storageManager calculate snapshot first, then update it into the workerInfo). 

### Related issues.
#635 

### Related pull requests.


### How was this patch tested?


/cc @AngersZhuuuu 

/assign @main-reviewer
