### PR TITLE
[BUILD] lz4 and zstd should respect Spark build-in versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,8 +72,6 @@
     <junit.version>4.12</junit.version>
     <leveldb.version>1.8</leveldb.version>
     <log4j2.version>2.17.1</log4j2.version>
-    <lz4-java.version>1.8.0</lz4-java.version>
-    <zstd-jni.version>1.5.2-3</zstd-jni.version>
     <mockito.version>1.10.19</mockito.version>
     <mockito-scalatest.version>1.16.37</mockito-scalatest.version>
     <netty.version>4.1.77.Final</netty.version>
@@ -826,9 +824,11 @@
       <properties>
         <jackson.version>2.6.7</jackson.version>
         <jackson.databind.version>2.6.7.3</jackson.databind.version>
+        <lz4-java.version>1.4.0</lz4-java.version>
         <scala.version>2.11.12</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
         <spark.version>2.4.8</spark.version>
+        <zstd-jni.version>1.4.4-3</zstd-jni.version>
         <celeborn.shuffle.manager>shuffle-manager-2</celeborn.shuffle.manager>
       </properties>
       <dependencies>
@@ -854,9 +854,11 @@
       <properties>
         <jackson.version>2.10.0</jackson.version>
         <jackson.databind.version>2.10.0</jackson.databind.version>
+        <lz4-java.version>1.7.1</lz4-java.version>
         <scala.version>2.12.10</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.0.3</spark.version>
+        <zstd-jni.version>1.4.4-3</zstd-jni.version>
         <celeborn.shuffle.manager>shuffle-manager-3</celeborn.shuffle.manager>
       </properties>
       <dependencies>
@@ -882,9 +884,11 @@
       <properties>
         <jackson.version>2.10.0</jackson.version>
         <jackson.databind.version>2.10.0</jackson.databind.version>
+        <lz4-java.version>1.7.1</lz4-java.version>
         <scala.version>2.12.10</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.1.3</spark.version>
+        <zstd-jni.version>1.4.8-1</zstd-jni.version>
         <celeborn.shuffle.manager>shuffle-manager-3</celeborn.shuffle.manager>
       </properties>
       <dependencies>
@@ -910,9 +914,11 @@
       <properties>
         <jackson.version>2.12.3</jackson.version>
         <jackson.databind.version>2.12.3</jackson.databind.version>
+        <lz4-java.version>1.7.1</lz4-java.version>
         <scala.version>2.12.15</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.2.2</spark.version>
+        <zstd-jni.version>1.5.0-4</zstd-jni.version>
         <celeborn.shuffle.manager>shuffle-manager-3</celeborn.shuffle.manager>
       </properties>
       <dependencies>
@@ -938,9 +944,11 @@
       <properties>
         <jackson.version>2.13.3</jackson.version>
         <jackson.databind.version>2.13.3</jackson.databind.version>
+        <lz4-java.version>1.8.0</lz4-java.version>
         <scala.version>2.12.15</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.3.0</spark.version>
+        <zstd-jni.version>1.5.2-1</zstd-jni.version>
         <celeborn.shuffle.manager>shuffle-manager-3</celeborn.shuffle.manager>
       </properties>
       <dependencies>


### PR DESCRIPTION
# [BUG]/[FEATURE] title

### What changes were proposed in this pull request?

lz4 and zstd should respect Spark build-in versions

### Why are the changes needed?

Since compression and decompression occurs on Spark side, and Celeborn does not ship lz4/zstd classes, we should always respect Spark build-in versions

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
