### PR TITLE
[K8S] Should move common env to values.yml instead of set in each yaml

### DIFF
--- a/docker/helm/templates/master-statefulset.yaml
+++ b/docker/helm/templates/master-statefulset.yaml
@@ -92,10 +92,6 @@ spec:
           - name: {{ include "celeborn.fullname" . }}-master-ratis
             mountPath: {{get .Values.celeborn "rss.ha.storage.dir"}}
         env:
-          - name:  TZ
-            value: "Asia/Shanghai"
-          - name:  RSS_NO_DAEMONIZE
-            value: "yes"
           {{- range $key, $val := .Values.environments }}
           - name: {{ $key }}
             value: {{ $val | quote }}

--- a/docker/helm/templates/worker-statefulset.yaml
+++ b/docker/helm/templates/worker-statefulset.yaml
@@ -96,10 +96,6 @@ spec:
             name: vol-{{ $index }}
           {{- end }}
         env:
-          - name:  TZ
-            value: "Asia/Shanghai"
-          - name:  RSS_NO_DAEMONIZE
-            value: "yes"
           {{- range $key, $val := .Values.environments }}
           - name: {{ $key }}
             value: {{ $val | quote }}

--- a/docker/helm/values.yaml
+++ b/docker/helm/values.yaml
@@ -65,6 +65,8 @@ environments:
   RSS_MASTER_MEMORY: 2g
   RSS_WORKER_JAVA_OPTS: "-XX:-PrintGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:gc-worker.out -Dio.netty.leakDetectionLevel=advanced"
   RSS_WORKER_OFFHEAP_MEMORY: 12g
+  CELEBORN_NO_DAEMONIZE: "yes"
+  TZ: "Asia/Shanghai"
 
 podMonitor:
   enable: true


### PR DESCRIPTION
# [BUG] & [IMPROVE] [K8S] Should move common env to values.yml instead of set in each yaml

### What changes were proposed in this pull request?
Common environment variables should be grouped together in values.yaml instead of scattered in each pod file, for easier modifications with user setting and devs improve.

Also, rename `RSS_NO_DAEMONIZE` to `CELEBORN_NO_DAEMONIZE `,  according to #724 

### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
