### PR TITLE
[ISSUE-751][REFACTOR] Move userResourceConsumption to WorkerInfo's parameter and format WorkerInfo's toString()

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/util/PbSerDeUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/PbSerDeUtils.java
@@ -27,7 +27,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.celeborn.common.meta.DiskInfo;
 import org.apache.celeborn.common.meta.FileInfo;
 import org.apache.celeborn.common.protocol.*;
-import org.apache.celeborn.common.protocol.message.ControlMessages.ResourceConsumption;
+import org.apache.celeborn.common.protocol.message.ControlMessages.*;
 
 public class PbSerDeUtils {
   public static Set<String> fromPbSortedShuffleFileSet(byte[] data)
@@ -125,7 +125,7 @@ public class PbSerDeUtils {
   }
 
   public static ResourceConsumption fromPbResourceConsumption(
-      PbResourceConsumption pbResourceConsumption) throws InvalidProtocolBufferException {
+      PbResourceConsumption pbResourceConsumption) {
     return new ResourceConsumption(
         pbResourceConsumption.getDiskBytesWritten(),
         pbResourceConsumption.getDiskFileCount(),
@@ -141,5 +141,20 @@ public class PbSerDeUtils {
         .setHdfsBytesWritten(resourceConsumption.hdfsBytesWritten())
         .setHdfsFileCount(resourceConsumption.hdfsFileCount())
         .build();
+  }
+
+  public static Map<UserIdentifier, ResourceConsumption> fromPbUserResourceConsumption(
+      Map<String, PbResourceConsumption> pbUserResourceConsumption) {
+    Map<UserIdentifier, ResourceConsumption> map = new ConcurrentHashMap<>();
+    pbUserResourceConsumption.forEach(
+        (k, v) -> map.put(UserIdentifier$.MODULE$.apply(k), fromPbResourceConsumption(v)));
+    return map;
+  }
+
+  public static Map<String, PbResourceConsumption> toPbUserResourceConsumption(
+      Map<UserIdentifier, ResourceConsumption> userResourceConsumption) {
+    Map<String, PbResourceConsumption> map = new ConcurrentHashMap<>();
+    userResourceConsumption.forEach((k, v) -> map.put(k.toString(), toPbResourceConsumption(v)));
+    return map;
   }
 }

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -113,6 +113,7 @@ message PbWorkerInfo {
   int32 fetchPort = 4;
   int32 replicatePort = 5;
   repeated PbDiskInfo disks = 6;
+  map<string, PbResourceConsumption> userResourceConsumption = 7;
 }
 
 message PbFileGroup {

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -242,7 +242,7 @@ class WorkerInfo(
        |PushPort: $pushPort
        |FetchPort: $fetchPort
        |ReplicatePort: $replicatePort
-       |SlotsUsed: $usedSlots()
+       |SlotsUsed: $usedSlots
        |LastHeartbeat: $lastHeartbeat
        |Disks: $diskInfosString
        |UserResourceConsumption: $userResourceConsumptionString
@@ -260,7 +260,7 @@ class WorkerInfo(
   }
 
   override def hashCode(): Int = {
-    Objects.hashCode(host, rpcPort, pushPort, fetchPort, replicatePort)
+    Objects.hashCode(host, rpcPort, pushPort, fetchPort)
   }
 }
 
@@ -280,14 +280,8 @@ object WorkerInfo {
       } else {
         new util.HashMap[String, DiskInfo]()
       }
-    val userResourceConsumption = pbWorkerInfo
-      .getUserResourceConsumptionMap
-      .asScala
-      .map { case (userInfo, pbResourceConsumption) =>
-        (UserIdentifier(userInfo), pbResourceConsumption)
-      }
-      .mapValues(PbSerDeUtils.fromPbResourceConsumption)
-      .asJava
+    val userResourceConsumption =
+      PbSerDeUtils.fromPbUserResourceConsumption(pbWorkerInfo.getUserResourceConsumptionMap)
 
     new WorkerInfo(
       pbWorkerInfo.getHost,
@@ -304,13 +298,8 @@ object WorkerInfo {
     val disks = workerInfo.diskInfos.asScala.values
       .map { diskInfo => PbSerDeUtils.toPbDiskInfo(diskInfo) }
       .asJava
-    val pbUserResourceConsumption = workerInfo.userResourceConsumption
-      .asScala
-      .map { case (userIdentifier, resourceConsumption) =>
-        (userIdentifier.toString, resourceConsumption)
-      }
-      .mapValues(PbSerDeUtils.toPbResourceConsumption)
-      .asJava
+    val pbUserResourceConsumption =
+      PbSerDeUtils.toPbUserResourceConsumption(workerInfo.userResourceConsumption)
     PbWorkerInfo
       .newBuilder()
       .setHost(workerInfo.host)

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -230,11 +230,11 @@ class WorkerInfo(
 
   override def toString(): String = {
     val diskInfosString = diskInfos.values().asScala.zipWithIndex.map { case (diskInfo, index) =>
-      s"\n  DiskInfo ${index}: ${diskInfo}"
+      s"\n  DiskInfo${index}: ${diskInfo}"
     }.mkString("")
     val userResourceConsumptionString =
       userResourceConsumption.asScala.map { case (userIdentifier, resourceConsumption) =>
-        s"\n UserIdentifier: ${userIdentifier}, ResourceConsumption: ${resourceConsumption}"
+        s"\n  UserIdentifier: ${userIdentifier}, ResourceConsumption: ${resourceConsumption}"
       }.mkString("")
     s"""
        |Host: $host

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -229,21 +229,23 @@ class WorkerInfo(
   }
 
   override def toString(): String = {
-    val (diskInfosString, slots) = if (diskInfos != null) {
-      val str = diskInfos.values().asScala.zipWithIndex.map { case (diskInfo, index) =>
-        s"\n  DiskInfo${index}: ${diskInfo}"
-      }.mkString("")
-      (str, usedSlots)
-    } else {
-      ("null", 0)
-    }
-    val userResourceConsumptionString = if (userResourceConsumption != null) {
-      userResourceConsumption.asScala.map { case (userIdentifier, resourceConsumption) =>
-        s"\n  UserIdentifier: ${userIdentifier}, ResourceConsumption: ${resourceConsumption}"
-      }.mkString("")
-    } else {
-      "null"
-    }
+    val (diskInfosString, slots) =
+      if (diskInfos != null) {
+        val str = diskInfos.values().asScala.zipWithIndex.map { case (diskInfo, index) =>
+          s"\n  DiskInfo${index}: ${diskInfo}"
+        }.mkString("")
+        (str, usedSlots)
+      } else {
+        ("null", 0)
+      }
+    val userResourceConsumptionString =
+      if (userResourceConsumption != null) {
+        userResourceConsumption.asScala.map { case (userIdentifier, resourceConsumption) =>
+          s"\n  UserIdentifier: ${userIdentifier}, ResourceConsumption: ${resourceConsumption}"
+        }.mkString("")
+      } else {
+        "null"
+      }
     s"""
        |Host: $host
        |RpcPort: $rpcPort

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -229,6 +229,13 @@ class WorkerInfo(
   }
 
   override def toString(): String = {
+    val diskInfosString = diskInfos.values().asScala.zipWithIndex.map { case (diskInfo, index) =>
+      s"\n  DiskInfo ${index}: ${diskInfo}"
+    }.mkString("")
+    val userResourceConsumptionString =
+      userResourceConsumption.asScala.map { case (userIdentifier, resourceConsumption) =>
+        s"\n UserIdentifier: ${userIdentifier}, ResourceConsumption: ${resourceConsumption}"
+      }.mkString("")
     s"""
        |Host: $host
        |RpcPort: $rpcPort
@@ -237,7 +244,8 @@ class WorkerInfo(
        |ReplicatePort: $replicatePort
        |SlotsUsed: $usedSlots()
        |LastHeartbeat: $lastHeartbeat
-       |Disks: $diskInfos
+       |Disks: $diskInfosString
+       |UserResourceConsumption: $userResourceConsumptionString
        |WorkerRef: $endpoint
        |""".stripMargin
   }

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -229,20 +229,28 @@ class WorkerInfo(
   }
 
   override def toString(): String = {
-    val diskInfosString = diskInfos.values().asScala.zipWithIndex.map { case (diskInfo, index) =>
-      s"\n  DiskInfo${index}: ${diskInfo}"
-    }.mkString("")
-    val userResourceConsumptionString =
+    val (diskInfosString, slots) = if (diskInfos != null) {
+      val str = diskInfos.values().asScala.zipWithIndex.map { case (diskInfo, index) =>
+        s"\n  DiskInfo${index}: ${diskInfo}"
+      }.mkString("")
+      (str, usedSlots)
+    } else {
+      ("null", 0)
+    }
+    val userResourceConsumptionString = if (userResourceConsumption != null) {
       userResourceConsumption.asScala.map { case (userIdentifier, resourceConsumption) =>
         s"\n  UserIdentifier: ${userIdentifier}, ResourceConsumption: ${resourceConsumption}"
       }.mkString("")
+    } else {
+      "null"
+    }
     s"""
        |Host: $host
        |RpcPort: $rpcPort
        |PushPort: $pushPort
        |FetchPort: $fetchPort
        |ReplicatePort: $replicatePort
-       |SlotsUsed: $usedSlots
+       |SlotsUsed: $slots
        |LastHeartbeat: $lastHeartbeat
        |Disks: $diskInfosString
        |UserResourceConsumption: $userResourceConsumptionString

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -434,6 +434,14 @@ object ControlMessages extends Logging {
         hdfsBytesWritten + other.hdfsBytesWritten,
         hdfsFileCount + other.hdfsFileCount)
     }
+
+    override def toString: String = {
+      val GiB = 1024 * 1024 * 1024 * 1.0;
+      s"ResourceConsumption(diskBytesWritten: ${(diskBytesWritten / GiB).formatted("%.3f")} GiB," +
+        s" diskFileCount: ${diskFileCount}," +
+        s" hdfsBytesWritten: ${(hdfsBytesWritten / GiB).formatted("%.3f")} GiB," +
+        s" hdfsFileCount: ${hdfsFileCount})"
+    }
   }
 
   // TODO change message type to GeneratedMessageV3

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -819,11 +819,10 @@ object ControlMessages extends Logging {
         val userResourceConsumption = pbHeartbeatFromWorker
           .getUserResourceConsumptionMap
           .asScala
-          .map { case (userInfo, resourceConsumption) =>
-            (UserIdentifier(userInfo), resourceConsumption)
+          .map { case (userInfo, pbResourceConsumption) =>
+            (UserIdentifier(userInfo), pbResourceConsumption)
           }
           .mapValues(PbSerDeUtils.fromPbResourceConsumption)
-          .toMap
           .asJava
         val pbDisks = pbHeartbeatFromWorker.getDisksList.asScala.map(PbSerDeUtils.fromPbDiskInfo)
         if (pbHeartbeatFromWorker.getShuffleKeysCount > 0) {

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -632,7 +632,7 @@ object ControlMessages extends Logging {
 
     case GetBlacklist(localBlacklist) =>
       val payload = PbGetBlacklist.newBuilder()
-        .addAllLocalBlackList(localBlacklist.asScala.map(WorkerInfo.toPbWorkerInfo)
+        .addAllLocalBlackList(localBlacklist.asScala.map(PbSerDeUtils.toPbWorkerInfo)
           .toList.asJava)
         .build().toByteArray
       new TransportMessage(MessageType.GET_BLACKLIST, payload)
@@ -640,9 +640,9 @@ object ControlMessages extends Logging {
     case GetBlacklistResponse(statusCode, blacklist, unknownWorkers) =>
       val builder = PbGetBlacklistResponse.newBuilder()
         .setStatus(statusCode.getValue)
-      builder.addAllBlacklist(blacklist.asScala.map(WorkerInfo.toPbWorkerInfo).toList.asJava)
+      builder.addAllBlacklist(blacklist.asScala.map(PbSerDeUtils.toPbWorkerInfo).toList.asJava)
       builder.addAllUnknownWorkers(
-        unknownWorkers.asScala.map(WorkerInfo.toPbWorkerInfo).toList.asJava)
+        unknownWorkers.asScala.map(PbSerDeUtils.toPbWorkerInfo).toList.asJava)
       val payload = builder.build().toByteArray
       new TransportMessage(MessageType.GET_BLACKLIST_RESPONSE, payload)
 
@@ -665,7 +665,7 @@ object ControlMessages extends Logging {
 
     case ReportWorkerFailure(failed, requestId) =>
       val payload = PbReportWorkerFailure.newBuilder()
-        .addAllFailed(failed.asScala.map(WorkerInfo.toPbWorkerInfo(_)).toList.asJava)
+        .addAllFailed(failed.asScala.map(PbSerDeUtils.toPbWorkerInfo(_)).toList.asJava)
         .setRequestId(requestId).build().toByteArray
       new TransportMessage(MessageType.REPORT_WORKER_FAILURE, payload)
 
@@ -781,7 +781,7 @@ object ControlMessages extends Logging {
     case GetWorkerInfosResponse(status, workerInfos @ _*) =>
       val payload = PbGetWorkerInfosResponse.newBuilder()
         .setStatus(status.getValue)
-        .addAllWorkerInfos(workerInfos.map(WorkerInfo.toPbWorkerInfo(_)).toList.asJava)
+        .addAllWorkerInfos(workerInfos.map(PbSerDeUtils.toPbWorkerInfo(_)).toList.asJava)
         .build().toByteArray
       new TransportMessage(MessageType.GET_WORKER_INFO_RESPONSE, payload)
 
@@ -943,16 +943,16 @@ object ControlMessages extends Logging {
       case GET_BLACKLIST =>
         val pbGetBlacklist = PbGetBlacklist.parseFrom(message.getPayload)
         GetBlacklist(new util.ArrayList[WorkerInfo](pbGetBlacklist.getLocalBlackListList.asScala
-          .map(WorkerInfo.fromPbWorkerInfo).toList.asJava))
+          .map(PbSerDeUtils.fromPbWorkerInfo).toList.asJava))
 
       case GET_BLACKLIST_RESPONSE =>
         val pbGetBlacklistResponse = PbGetBlacklistResponse.parseFrom(message.getPayload)
         GetBlacklistResponse(
           Utils.toStatusCode(pbGetBlacklistResponse.getStatus),
           pbGetBlacklistResponse.getBlacklistList.asScala
-            .map(WorkerInfo.fromPbWorkerInfo).toList.asJava,
+            .map(PbSerDeUtils.fromPbWorkerInfo).toList.asJava,
           pbGetBlacklistResponse.getUnknownWorkersList.asScala
-            .map(WorkerInfo.fromPbWorkerInfo).toList.asJava)
+            .map(PbSerDeUtils.fromPbWorkerInfo).toList.asJava)
 
       case CHECK_QUOTA =>
         val pbCheckAvailable = PbCheckQuota.parseFrom(message.getPayload)
@@ -970,7 +970,7 @@ object ControlMessages extends Logging {
         val pbReportWorkerFailure = PbReportWorkerFailure.parseFrom(message.getPayload)
         ReportWorkerFailure(
           new util.ArrayList[WorkerInfo](pbReportWorkerFailure.getFailedList
-            .asScala.map(WorkerInfo.fromPbWorkerInfo(_)).toList.asJava),
+            .asScala.map(PbSerDeUtils.fromPbWorkerInfo).toList.asJava),
           pbReportWorkerFailure.getRequestId)
 
       case REGISTER_WORKER_RESPONSE =>
@@ -1065,7 +1065,7 @@ object ControlMessages extends Logging {
         GetWorkerInfosResponse(
           Utils.toStatusCode(pbGetWorkerInfoResponse.getStatus),
           pbGetWorkerInfoResponse.getWorkerInfosList.asScala
-            .map(WorkerInfo.fromPbWorkerInfo(_)).toList: _*)
+            .map(PbSerDeUtils.fromPbWorkerInfo).toList: _*)
 
       case THREAD_DUMP =>
         ThreadDump

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
@@ -19,7 +19,7 @@ package org.apache.celeborn.common.meta
 
 import java.util
 import java.util.{Map => jMap}
-import java.util.concurrent.{Future, ThreadLocalRandom}
+import java.util.concurrent.{ConcurrentHashMap, Future, ThreadLocalRandom}
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.mutable.ArrayBuffer
@@ -28,6 +28,7 @@ import scala.concurrent.duration._
 import org.junit.Assert.{assertEquals, assertNotEquals, assertNotNull}
 
 import org.apache.celeborn.RssFunSuite
+import org.apache.celeborn.common.protocol.message.ControlMessages.{ResourceConsumption, UserIdentifier}
 import org.apache.celeborn.common.util.ThreadUtils
 
 class WorkerInfoSuite extends RssFunSuite {
@@ -61,7 +62,10 @@ class WorkerInfoSuite extends RssFunSuite {
     disks.put("disk1", new DiskInfo("disk1", Int.MaxValue, 1, 0))
     disks.put("disk2", new DiskInfo("disk2", Int.MaxValue, 1, 0))
     disks.put("disk3", new DiskInfo("disk3", Int.MaxValue, 1, 0))
-    val worker = new WorkerInfo("localhost", 10000, 10001, 10002, 10003, disks, null)
+    val userResourceConsumption = new ConcurrentHashMap[UserIdentifier, ResourceConsumption]()
+    userResourceConsumption.put(UserIdentifier("tenant1", "name1"), ResourceConsumption(1, 1, 1, 1))
+    val worker =
+      new WorkerInfo("localhost", 10000, 10001, 10002, 10003, disks, userResourceConsumption, null)
 
     val allocatedSlots = new AtomicInteger(0)
     val shuffleKey = "appId-shuffleId"
@@ -127,32 +131,32 @@ class WorkerInfoSuite extends RssFunSuite {
   }
 
   test("WorkerInfo not equals when host different.") {
-    val worker1 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, null, null)
-    val worker2 = new WorkerInfo("h2", 10001, 10002, 10003, 1000, null, null)
+    val worker1 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, null, null, null)
+    val worker2 = new WorkerInfo("h2", 10001, 10002, 10003, 1000, null, null, null)
     assertNotEquals(worker1, worker2)
   }
 
   test("WorkerInfo not equals when rpc port different.") {
-    val worker1 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, null, null)
-    val worker2 = new WorkerInfo("h1", 20001, 10002, 10003, 1000, null, null)
+    val worker1 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, null, null, null)
+    val worker2 = new WorkerInfo("h1", 20001, 10002, 10003, 1000, null, null, null)
     assertNotEquals(worker1, worker2)
   }
 
   test("WorkerInfo not equals when push port different.") {
-    val worker1 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, null, null)
-    val worker2 = new WorkerInfo("h1", 10001, 20002, 10003, 1000, null, null)
+    val worker1 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, null, null, null)
+    val worker2 = new WorkerInfo("h1", 10001, 20002, 10003, 1000, null, null, null)
     assertNotEquals(worker1, worker2)
   }
 
   test("WorkerInfo not equals when fetch port different.") {
-    val worker1 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, null, null)
-    val worker2 = new WorkerInfo("h1", 10001, 10002, 20003, 1000, null, null)
+    val worker1 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, null, null, null)
+    val worker2 = new WorkerInfo("h1", 10001, 10002, 20003, 1000, null, null, null)
     assertNotEquals(worker1, worker2)
   }
 
   test("WorkerInfo not equals when replicate port different.") {
-    val worker1 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, null, null)
-    val worker2 = new WorkerInfo("h1", 10001, 10002, 10003, 2000, null, null)
+    val worker1 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, null, null, null)
+    val worker2 = new WorkerInfo("h1", 10001, 10002, 10003, 2000, null, null, null)
     assertNotEquals(worker1, worker2)
   }
 }

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
@@ -28,8 +28,13 @@ import scala.concurrent.duration._
 import org.junit.Assert.{assertEquals, assertNotEquals, assertNotNull}
 
 import org.apache.celeborn.RssFunSuite
+import org.apache.celeborn.common.RssConf
 import org.apache.celeborn.common.protocol.message.ControlMessages.{ResourceConsumption, UserIdentifier}
+import org.apache.celeborn.common.rpc.netty.{NettyRpcEndpointRef, NettyRpcEnv}
+import org.apache.celeborn.common.rpc.{RpcAddress, RpcEndpointAddress, RpcEndpointRef, RpcEnv, RpcTimeout}
 import org.apache.celeborn.common.util.ThreadUtils
+
+import scala.reflect.ClassTag
 
 class WorkerInfoSuite extends RssFunSuite {
 
@@ -158,5 +163,121 @@ class WorkerInfoSuite extends RssFunSuite {
     val worker1 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, null, null, null)
     val worker2 = new WorkerInfo("h1", 10001, 10002, 10003, 2000, null, null, null)
     assertNotEquals(worker1, worker2)
+  }
+
+  test("WorkerInfo equals when diskInfos different") {
+    val worker1 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, new util.HashMap[String, DiskInfo](), null, null)
+    val worker2 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, null, null, null)
+    assertEquals(worker1, worker2)
+  }
+
+  test("WorkerInfo equals when userResourceConsumption different") {
+    val worker1 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, null, new util.HashMap[UserIdentifier, ResourceConsumption](), null)
+    val worker2 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, null, null, null)
+    assertEquals(worker1, worker2)
+  }
+
+  test("WorkerInfo equals when endpoint different") {
+    val mockEndpoint = new RpcEndpointRef(new RssConf()) {
+
+      override def address: RpcAddress = ???
+
+      override def name: String = ???
+
+      override def send(message: Any): Unit = ???
+
+      override def ask[T: ClassTag](message: Any, timeout: RpcTimeout): concurrent.Future[T] = ???
+    }
+    val worker1 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, null, null, mockEndpoint)
+    val worker2 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, null, null, null)
+    assertEquals(worker1, worker2)
+  }
+
+  test("WorkerInfo toString output") {
+    val worker1 = new WorkerInfo("h1", 10001, 10002, 10003, 1000)
+    val worker2 = new WorkerInfo("h2", 20001, 20002, 20003, 2000, null, null, null)
+
+    val worker3 = new WorkerInfo("h3", 30001, 30002, 30003, 3000, new util.HashMap[String, DiskInfo](), null, null)
+
+    val disks = new util.HashMap[String, DiskInfo]()
+    disks.put("disk1", new DiskInfo("disk1", Int.MaxValue, 1, 10))
+    disks.put("disk2", new DiskInfo("disk2", Int.MaxValue, 2, 20))
+    disks.put("disk3", new DiskInfo("disk3", Int.MaxValue, 3, 30))
+    val userResourceConsumption = new ConcurrentHashMap[UserIdentifier, ResourceConsumption]()
+    userResourceConsumption.put(UserIdentifier("tenant1", "name1"), ResourceConsumption(20971520, 1, 52428800, 1))
+    val conf = new RssConf()
+    val endpointAddress = new RpcEndpointAddress(new RpcAddress("localhost",12345),"mockRpc")
+    val rpcEnv = RpcEnv.create("mockEnv", "localhost", "localhost", 12345, conf, 64)
+    val rpcEndpointRef = new NettyRpcEndpointRef(conf, endpointAddress, rpcEnv.asInstanceOf[NettyRpcEnv])
+    val worker4 = new WorkerInfo("h4", 40001, 40002, 40003, 4000, disks, userResourceConsumption, rpcEndpointRef)
+
+    val placeholder = ""
+    val exp1 =
+      s"""
+        |Host: h1
+        |RpcPort: 10001
+        |PushPort: 10002
+        |FetchPort: 10003
+        |ReplicatePort: 1000
+        |SlotsUsed: 0
+        |LastHeartbeat: 0
+        |Disks: $placeholder
+        |UserResourceConsumption: $placeholder
+        |WorkerRef: null
+        |""".stripMargin
+
+    val exp2 =
+      """
+        |Host: h2
+        |RpcPort: 20001
+        |PushPort: 20002
+        |FetchPort: 20003
+        |ReplicatePort: 2000
+        |SlotsUsed: 0
+        |LastHeartbeat: 0
+        |Disks: null
+        |UserResourceConsumption: null
+        |WorkerRef: null
+        |""".stripMargin
+    val exp3 =
+      s"""
+        |Host: h3
+        |RpcPort: 30001
+        |PushPort: 30002
+        |FetchPort: 30003
+        |ReplicatePort: 3000
+        |SlotsUsed: 0
+        |LastHeartbeat: 0
+        |Disks: $placeholder
+        |UserResourceConsumption: null
+        |WorkerRef: null
+        |""".stripMargin
+    val exp4 =
+      s"""
+        |Host: h4
+        |RpcPort: 40001
+        |PushPort: 40002
+        |FetchPort: 40003
+        |ReplicatePort: 4000
+        |SlotsUsed: 60
+        |LastHeartbeat: 0
+        |Disks: $placeholder
+        |  DiskInfo0: DiskInfo(maxSlots: 0, committed shuffles 0 shuffleAllocations: Map(), mountPoint: disk3, usableSpace: 2147483647, avgFlushTime: 3, activeSlots: 30) status: HEALTHY dirs $placeholder
+        |  DiskInfo1: DiskInfo(maxSlots: 0, committed shuffles 0 shuffleAllocations: Map(), mountPoint: disk1, usableSpace: 2147483647, avgFlushTime: 1, activeSlots: 10) status: HEALTHY dirs $placeholder
+        |  DiskInfo2: DiskInfo(maxSlots: 0, committed shuffles 0 shuffleAllocations: Map(), mountPoint: disk2, usableSpace: 2147483647, avgFlushTime: 2, activeSlots: 20) status: HEALTHY dirs $placeholder
+        |UserResourceConsumption: $placeholder
+        |  UserIdentifier: `tenant1`.`name1`, ResourceConsumption: ResourceConsumption(diskBytesWritten: 20.0 MB, diskFileCount: 1, hdfsBytesWritten: 50.0 MB, hdfsFileCount: 1)
+        |WorkerRef: NettyRpcEndpointRef(rss://mockRpc@localhost:12345)
+        |""".stripMargin;
+
+    println(worker1)
+    println(worker2)
+    println(worker3)
+    println(worker4)
+
+    assertEquals(exp1, worker1.toString)
+    assertEquals(exp2, worker2.toString)
+    assertEquals(exp3, worker3.toString)
+    assertEquals(exp4, worker4.toString)
   }
 }

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
@@ -24,17 +24,16 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration._
+import scala.reflect.ClassTag
 
 import org.junit.Assert.{assertEquals, assertNotEquals, assertNotNull}
 
 import org.apache.celeborn.RssFunSuite
 import org.apache.celeborn.common.RssConf
 import org.apache.celeborn.common.protocol.message.ControlMessages.{ResourceConsumption, UserIdentifier}
-import org.apache.celeborn.common.rpc.netty.{NettyRpcEndpointRef, NettyRpcEnv}
 import org.apache.celeborn.common.rpc.{RpcAddress, RpcEndpointAddress, RpcEndpointRef, RpcEnv, RpcTimeout}
+import org.apache.celeborn.common.rpc.netty.{NettyRpcEndpointRef, NettyRpcEnv}
 import org.apache.celeborn.common.util.ThreadUtils
-
-import scala.reflect.ClassTag
 
 class WorkerInfoSuite extends RssFunSuite {
 
@@ -166,13 +165,29 @@ class WorkerInfoSuite extends RssFunSuite {
   }
 
   test("WorkerInfo equals when diskInfos different") {
-    val worker1 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, new util.HashMap[String, DiskInfo](), null, null)
+    val worker1 = new WorkerInfo(
+      "h1",
+      10001,
+      10002,
+      10003,
+      1000,
+      new util.HashMap[String, DiskInfo](),
+      null,
+      null)
     val worker2 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, null, null, null)
     assertEquals(worker1, worker2)
   }
 
   test("WorkerInfo equals when userResourceConsumption different") {
-    val worker1 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, null, new util.HashMap[UserIdentifier, ResourceConsumption](), null)
+    val worker1 = new WorkerInfo(
+      "h1",
+      10001,
+      10002,
+      10003,
+      1000,
+      null,
+      new util.HashMap[UserIdentifier, ResourceConsumption](),
+      null)
     val worker2 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, null, null, null)
     assertEquals(worker1, worker2)
   }
@@ -197,34 +212,53 @@ class WorkerInfoSuite extends RssFunSuite {
     val worker1 = new WorkerInfo("h1", 10001, 10002, 10003, 1000)
     val worker2 = new WorkerInfo("h2", 20001, 20002, 20003, 2000, null, null, null)
 
-    val worker3 = new WorkerInfo("h3", 30001, 30002, 30003, 3000, new util.HashMap[String, DiskInfo](), null, null)
+    val worker3 = new WorkerInfo(
+      "h3",
+      30001,
+      30002,
+      30003,
+      3000,
+      new util.HashMap[String, DiskInfo](),
+      null,
+      null)
 
     val disks = new util.HashMap[String, DiskInfo]()
     disks.put("disk1", new DiskInfo("disk1", Int.MaxValue, 1, 10))
     disks.put("disk2", new DiskInfo("disk2", Int.MaxValue, 2, 20))
     disks.put("disk3", new DiskInfo("disk3", Int.MaxValue, 3, 30))
     val userResourceConsumption = new ConcurrentHashMap[UserIdentifier, ResourceConsumption]()
-    userResourceConsumption.put(UserIdentifier("tenant1", "name1"), ResourceConsumption(20971520, 1, 52428800, 1))
+    userResourceConsumption.put(
+      UserIdentifier("tenant1", "name1"),
+      ResourceConsumption(20971520, 1, 52428800, 1))
     val conf = new RssConf()
-    val endpointAddress = new RpcEndpointAddress(new RpcAddress("localhost",12345),"mockRpc")
+    val endpointAddress = new RpcEndpointAddress(new RpcAddress("localhost", 12345), "mockRpc")
     val rpcEnv = RpcEnv.create("mockEnv", "localhost", "localhost", 12345, conf, 64)
-    val rpcEndpointRef = new NettyRpcEndpointRef(conf, endpointAddress, rpcEnv.asInstanceOf[NettyRpcEnv])
-    val worker4 = new WorkerInfo("h4", 40001, 40002, 40003, 4000, disks, userResourceConsumption, rpcEndpointRef)
+    val rpcEndpointRef =
+      new NettyRpcEndpointRef(conf, endpointAddress, rpcEnv.asInstanceOf[NettyRpcEnv])
+    val worker4 = new WorkerInfo(
+      "h4",
+      40001,
+      40002,
+      40003,
+      4000,
+      disks,
+      userResourceConsumption,
+      rpcEndpointRef)
 
     val placeholder = ""
     val exp1 =
       s"""
-        |Host: h1
-        |RpcPort: 10001
-        |PushPort: 10002
-        |FetchPort: 10003
-        |ReplicatePort: 1000
-        |SlotsUsed: 0
-        |LastHeartbeat: 0
-        |Disks: $placeholder
-        |UserResourceConsumption: $placeholder
-        |WorkerRef: null
-        |""".stripMargin
+         |Host: h1
+         |RpcPort: 10001
+         |PushPort: 10002
+         |FetchPort: 10003
+         |ReplicatePort: 1000
+         |SlotsUsed: 0
+         |LastHeartbeat: 0
+         |Disks: $placeholder
+         |UserResourceConsumption: $placeholder
+         |WorkerRef: null
+         |""".stripMargin
 
     val exp2 =
       """
@@ -241,34 +275,34 @@ class WorkerInfoSuite extends RssFunSuite {
         |""".stripMargin
     val exp3 =
       s"""
-        |Host: h3
-        |RpcPort: 30001
-        |PushPort: 30002
-        |FetchPort: 30003
-        |ReplicatePort: 3000
-        |SlotsUsed: 0
-        |LastHeartbeat: 0
-        |Disks: $placeholder
-        |UserResourceConsumption: null
-        |WorkerRef: null
-        |""".stripMargin
+         |Host: h3
+         |RpcPort: 30001
+         |PushPort: 30002
+         |FetchPort: 30003
+         |ReplicatePort: 3000
+         |SlotsUsed: 0
+         |LastHeartbeat: 0
+         |Disks: $placeholder
+         |UserResourceConsumption: null
+         |WorkerRef: null
+         |""".stripMargin
     val exp4 =
       s"""
-        |Host: h4
-        |RpcPort: 40001
-        |PushPort: 40002
-        |FetchPort: 40003
-        |ReplicatePort: 4000
-        |SlotsUsed: 60
-        |LastHeartbeat: 0
-        |Disks: $placeholder
-        |  DiskInfo0: DiskInfo(maxSlots: 0, committed shuffles 0 shuffleAllocations: Map(), mountPoint: disk3, usableSpace: 2147483647, avgFlushTime: 3, activeSlots: 30) status: HEALTHY dirs $placeholder
-        |  DiskInfo1: DiskInfo(maxSlots: 0, committed shuffles 0 shuffleAllocations: Map(), mountPoint: disk1, usableSpace: 2147483647, avgFlushTime: 1, activeSlots: 10) status: HEALTHY dirs $placeholder
-        |  DiskInfo2: DiskInfo(maxSlots: 0, committed shuffles 0 shuffleAllocations: Map(), mountPoint: disk2, usableSpace: 2147483647, avgFlushTime: 2, activeSlots: 20) status: HEALTHY dirs $placeholder
-        |UserResourceConsumption: $placeholder
-        |  UserIdentifier: `tenant1`.`name1`, ResourceConsumption: ResourceConsumption(diskBytesWritten: 20.0 MB, diskFileCount: 1, hdfsBytesWritten: 50.0 MB, hdfsFileCount: 1)
-        |WorkerRef: NettyRpcEndpointRef(rss://mockRpc@localhost:12345)
-        |""".stripMargin;
+         |Host: h4
+         |RpcPort: 40001
+         |PushPort: 40002
+         |FetchPort: 40003
+         |ReplicatePort: 4000
+         |SlotsUsed: 60
+         |LastHeartbeat: 0
+         |Disks: $placeholder
+         |  DiskInfo0: DiskInfo(maxSlots: 0, committed shuffles 0 shuffleAllocations: Map(), mountPoint: disk3, usableSpace: 2147483647, avgFlushTime: 3, activeSlots: 30) status: HEALTHY dirs $placeholder
+         |  DiskInfo1: DiskInfo(maxSlots: 0, committed shuffles 0 shuffleAllocations: Map(), mountPoint: disk1, usableSpace: 2147483647, avgFlushTime: 1, activeSlots: 10) status: HEALTHY dirs $placeholder
+         |  DiskInfo2: DiskInfo(maxSlots: 0, committed shuffles 0 shuffleAllocations: Map(), mountPoint: disk2, usableSpace: 2147483647, avgFlushTime: 2, activeSlots: 20) status: HEALTHY dirs $placeholder
+         |UserResourceConsumption: $placeholder
+         |  UserIdentifier: `tenant1`.`name1`, ResourceConsumption: ResourceConsumption(diskBytesWritten: 20.0 MB, diskFileCount: 1, hdfsBytesWritten: 50.0 MB, hdfsFileCount: 1)
+         |WorkerRef: NettyRpcEndpointRef(rss://mockRpc@localhost:12345)
+         |""".stripMargin;
 
     println(worker1)
     println(worker2)

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
@@ -255,8 +255,8 @@ class WorkerInfoSuite extends RssFunSuite {
          |ReplicatePort: 1000
          |SlotsUsed: 0
          |LastHeartbeat: 0
-         |Disks: $placeholder
-         |UserResourceConsumption: $placeholder
+         |Disks: empty
+         |UserResourceConsumption: empty
          |WorkerRef: null
          |""".stripMargin
 
@@ -269,8 +269,8 @@ class WorkerInfoSuite extends RssFunSuite {
         |ReplicatePort: 2000
         |SlotsUsed: 0
         |LastHeartbeat: 0
-        |Disks: null
-        |UserResourceConsumption: null
+        |Disks: empty
+        |UserResourceConsumption: empty
         |WorkerRef: null
         |""".stripMargin
     val exp3 =
@@ -282,8 +282,8 @@ class WorkerInfoSuite extends RssFunSuite {
          |ReplicatePort: 3000
          |SlotsUsed: 0
          |LastHeartbeat: 0
-         |Disks: $placeholder
-         |UserResourceConsumption: null
+         |Disks: empty
+         |UserResourceConsumption: empty
          |WorkerRef: null
          |""".stripMargin
     val exp4 =

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -167,7 +167,15 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
       Map<UserIdentifier, ResourceConsumption> userResourceConsumption,
       long time) {
     WorkerInfo worker =
-        new WorkerInfo(host, rpcPort, pushPort, fetchPort, replicatePort, disks, null);
+        new WorkerInfo(
+            host,
+            rpcPort,
+            pushPort,
+            fetchPort,
+            replicatePort,
+            disks,
+            userResourceConsumption,
+            null);
     AtomicLong availableSlots = new AtomicLong();
     LOG.debug("update worker {}:{} heart beat {}", host, rpcPort, disks);
     synchronized (workers) {
@@ -198,7 +206,15 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
       Map<String, DiskInfo> disks,
       Map<UserIdentifier, ResourceConsumption> userResourceConsumption) {
     WorkerInfo workerInfo =
-        new WorkerInfo(host, rpcPort, pushPort, fetchPort, replicatePort, disks, null);
+        new WorkerInfo(
+            host,
+            rpcPort,
+            pushPort,
+            fetchPort,
+            replicatePort,
+            disks,
+            userResourceConsumption,
+            null);
     workerInfo.lastHeartbeat_$eq(System.currentTimeMillis());
 
     try {
@@ -209,7 +225,6 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
     }
 
     workerInfo.updateDiskMaxSlots(estimatedPartitionSize);
-    workerInfo.updateThenGetUserResourceConsumption(userResourceConsumption);
     synchronized (workers) {
       workers.add(workerInfo);
     }

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -20,7 +20,7 @@ package org.apache.celeborn.service.deploy.master
 import java.io.IOException
 import java.net.BindException
 import java.util
-import java.util.concurrent.{ScheduledFuture, TimeUnit}
+import java.util.concurrent.{ConcurrentHashMap, ScheduledFuture, TimeUnit}
 
 import scala.collection.JavaConverters._
 import scala.util.Random
@@ -226,8 +226,8 @@ private[celeborn] class Master(
       val userResourceConsumption = pbRegisterWorker
         .getUserResourceConsumptionMap
         .asScala
-        .map { case (userInfo, resourceConsumption) =>
-          (UserIdentifier(userInfo), resourceConsumption)
+        .map { case (userInfo, pbResourceConsumption) =>
+          (UserIdentifier(userInfo), pbResourceConsumption)
         }
         .mapValues(PbSerDeUtils.fromPbResourceConsumption)
         .asJava
@@ -403,6 +403,7 @@ private[celeborn] class Master(
       fetchPort,
       replicatePort,
       new util.HashMap[String, DiskInfo](),
+      new ConcurrentHashMap[UserIdentifier, ResourceConsumption](),
       null)
     val worker: WorkerInfo = workersSnapShot
       .asScala
@@ -432,7 +433,15 @@ private[celeborn] class Master(
       userResourceConsumption: util.Map[UserIdentifier, ResourceConsumption],
       requestId: String): Unit = {
     val workerToRegister =
-      new WorkerInfo(host, rpcPort, pushPort, fetchPort, replicatePort, disks, null)
+      new WorkerInfo(
+        host,
+        rpcPort,
+        pushPort,
+        fetchPort,
+        replicatePort,
+        disks,
+        userResourceConsumption,
+        null)
     if (workersSnapShot.contains(workerToRegister)) {
       logWarning(s"Receive RegisterWorker while worker" +
         s" ${workerToRegister.toString()} already exists, re-register.")
@@ -700,6 +709,7 @@ private[celeborn] class Master(
           -1,
           -1,
           new util.HashMap[String, DiskInfo](),
+          new ConcurrentHashMap[UserIdentifier, ResourceConsumption](),
           null))
         GetWorkerInfosResponse(StatusCode.FAILED, result.asScala: _*)
     }

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -223,14 +223,8 @@ private[celeborn] class Master(
       val disks = pbRegisterWorker.getDisksList.asScala
         .map { pbDiskInfo => pbDiskInfo.getMountPoint -> PbSerDeUtils.fromPbDiskInfo(pbDiskInfo) }
         .toMap.asJava
-      val userResourceConsumption = pbRegisterWorker
-        .getUserResourceConsumptionMap
-        .asScala
-        .map { case (userInfo, pbResourceConsumption) =>
-          (UserIdentifier(userInfo), pbResourceConsumption)
-        }
-        .mapValues(PbSerDeUtils.fromPbResourceConsumption)
-        .asJava
+      val userResourceConsumption =
+        PbSerDeUtils.fromPbUserResourceConsumption(pbRegisterWorker.getUserResourceConsumptionMap)
 
       logDebug(s"Received RegisterWorker request $requestId, $host:$pushPort:$replicatePort" +
         s" $disks.")

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorSuiteJ.java
@@ -94,9 +94,9 @@ public class SlotsAllocatorSuiteJ {
     disks3.put("/mnt/disk3", diskInfo9);
 
     ArrayList<WorkerInfo> workers = new ArrayList<>(3);
-    workers.add(new WorkerInfo("host1", 9, 10, 110, 113, disks1, null));
-    workers.add(new WorkerInfo("host2", 9, 11, 111, 114, disks2, null));
-    workers.add(new WorkerInfo("host3", 9, 12, 112, 115, disks3, null));
+    workers.add(new WorkerInfo("host1", 9, 10, 110, 113, disks1, null, null));
+    workers.add(new WorkerInfo("host2", 9, 11, 111, 114, disks2, null, null));
+    workers.add(new WorkerInfo("host3", 9, 12, 112, 115, disks3, null, null));
     return workers;
   }
 

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
@@ -218,13 +218,34 @@ public class DefaultMetaSystemSuiteJ {
 
     WorkerInfo workerInfo1 =
         new WorkerInfo(
-            HOSTNAME1, RPCPORT1, PUSHPORT1, FETCHPORT1, REPLICATEPORT1, disks1, dummyRef);
+            HOSTNAME1,
+            RPCPORT1,
+            PUSHPORT1,
+            FETCHPORT1,
+            REPLICATEPORT1,
+            disks1,
+            userResourceConsumption1,
+            dummyRef);
     WorkerInfo workerInfo2 =
         new WorkerInfo(
-            HOSTNAME2, RPCPORT2, PUSHPORT2, FETCHPORT2, REPLICATEPORT2, disks2, dummyRef);
+            HOSTNAME2,
+            RPCPORT2,
+            PUSHPORT2,
+            FETCHPORT2,
+            REPLICATEPORT2,
+            disks2,
+            userResourceConsumption2,
+            dummyRef);
     WorkerInfo workerInfo3 =
         new WorkerInfo(
-            HOSTNAME3, RPCPORT3, PUSHPORT3, FETCHPORT3, REPLICATEPORT3, disks3, dummyRef);
+            HOSTNAME3,
+            RPCPORT3,
+            PUSHPORT3,
+            FETCHPORT3,
+            REPLICATEPORT3,
+            disks3,
+            userResourceConsumption3,
+            dummyRef);
 
     Map<String, Map<String, Integer>> workersToAllocate = new HashMap<>();
     Map<String, Integer> allocation = new HashMap<>();
@@ -346,10 +367,24 @@ public class DefaultMetaSystemSuiteJ {
 
     WorkerInfo workerInfo1 =
         new WorkerInfo(
-            HOSTNAME1, RPCPORT1, PUSHPORT1, FETCHPORT1, REPLICATEPORT1, disks1, dummyRef);
+            HOSTNAME1,
+            RPCPORT1,
+            PUSHPORT1,
+            FETCHPORT1,
+            REPLICATEPORT1,
+            disks1,
+            userResourceConsumption1,
+            dummyRef);
     WorkerInfo workerInfo2 =
         new WorkerInfo(
-            HOSTNAME2, RPCPORT2, PUSHPORT2, FETCHPORT2, REPLICATEPORT2, disks2, dummyRef);
+            HOSTNAME2,
+            RPCPORT2,
+            PUSHPORT2,
+            FETCHPORT2,
+            REPLICATEPORT2,
+            disks2,
+            userResourceConsumption2,
+            dummyRef);
 
     Map<String, Map<String, Integer>> workersToAllocate = new HashMap<>();
     Map<String, Integer> allocation = new HashMap<>();
@@ -398,10 +433,24 @@ public class DefaultMetaSystemSuiteJ {
 
     WorkerInfo workerInfo1 =
         new WorkerInfo(
-            HOSTNAME1, RPCPORT1, PUSHPORT1, FETCHPORT1, REPLICATEPORT1, disks1, dummyRef);
+            HOSTNAME1,
+            RPCPORT1,
+            PUSHPORT1,
+            FETCHPORT1,
+            REPLICATEPORT1,
+            disks1,
+            userResourceConsumption1,
+            dummyRef);
     WorkerInfo workerInfo2 =
         new WorkerInfo(
-            HOSTNAME2, RPCPORT2, PUSHPORT2, FETCHPORT2, REPLICATEPORT2, disks2, dummyRef);
+            HOSTNAME2,
+            RPCPORT2,
+            PUSHPORT2,
+            FETCHPORT2,
+            REPLICATEPORT2,
+            disks2,
+            userResourceConsumption2,
+            dummyRef);
 
     Map<String, Map<String, Integer>> workersToAllocate = new HashMap<>();
     Map<String, Integer> allocation = new HashMap<>();
@@ -533,10 +582,24 @@ public class DefaultMetaSystemSuiteJ {
 
     WorkerInfo workerInfo1 =
         new WorkerInfo(
-            HOSTNAME1, RPCPORT1, PUSHPORT1, FETCHPORT1, REPLICATEPORT1, disks1, dummyRef);
+            HOSTNAME1,
+            RPCPORT1,
+            PUSHPORT1,
+            FETCHPORT1,
+            REPLICATEPORT1,
+            disks1,
+            userResourceConsumption1,
+            dummyRef);
     WorkerInfo workerInfo2 =
         new WorkerInfo(
-            HOSTNAME2, RPCPORT2, PUSHPORT2, FETCHPORT2, REPLICATEPORT2, disks2, dummyRef);
+            HOSTNAME2,
+            RPCPORT2,
+            PUSHPORT2,
+            FETCHPORT2,
+            REPLICATEPORT2,
+            disks2,
+            userResourceConsumption2,
+            dummyRef);
 
     List<WorkerInfo> failedWorkers = new ArrayList<>();
     failedWorkers.add(workerInfo1);

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Matcher;
 
@@ -38,6 +39,8 @@ import org.junit.Test;
 import org.apache.celeborn.common.RssConf;
 import org.apache.celeborn.common.meta.DiskInfo;
 import org.apache.celeborn.common.meta.WorkerInfo;
+import org.apache.celeborn.common.protocol.message.ControlMessages.ResourceConsumption;
+import org.apache.celeborn.common.protocol.message.ControlMessages.UserIdentifier;
 import org.apache.celeborn.common.util.Utils;
 import org.apache.celeborn.service.deploy.master.clustermeta.ResourceProtos;
 import org.apache.celeborn.service.deploy.master.clustermeta.ResourceProtos.RequestSlotsRequest;
@@ -177,20 +180,41 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
     disks1.put("disk1", new DiskInfo("disk1", 64 * 1024 * 1024 * 1024, 100, 0));
     disks1.put("disk2", new DiskInfo("disk2", 64 * 1024 * 1024 * 1024, 100, 0));
     disks1.put("disk3", new DiskInfo("disk3", 64 * 1024 * 1024 * 1024, 100, 0));
+    Map<UserIdentifier, ResourceConsumption> userResourceConsumption1 = new ConcurrentHashMap<>();
+    userResourceConsumption1.put(
+        new UserIdentifier("tenant1", "name1"), new ResourceConsumption(1000, 1, 1000, 1));
+    userResourceConsumption1.put(
+        new UserIdentifier("tenant1", "name2"), new ResourceConsumption(2000, 2, 2000, 2));
+    userResourceConsumption1.put(
+        new UserIdentifier("tenant1", "name3"), new ResourceConsumption(3000, 3, 3000, 3));
 
     Map<String, DiskInfo> disks2 = new HashMap<>();
     disks2.put("disk1", new DiskInfo("disk1", 64 * 1024 * 1024 * 1024, 100, 0));
     disks2.put("disk2", new DiskInfo("disk2", 64 * 1024 * 1024 * 1024, 100, 0));
     disks2.put("disk3", new DiskInfo("disk3", 64 * 1024 * 1024 * 1024, 100, 0));
+    Map<UserIdentifier, ResourceConsumption> userResourceConsumption2 = new ConcurrentHashMap<>();
+    userResourceConsumption2.put(
+        new UserIdentifier("tenant2", "name1"), new ResourceConsumption(1000, 1, 1000, 1));
+    userResourceConsumption2.put(
+        new UserIdentifier("tenant2", "name2"), new ResourceConsumption(2000, 2, 2000, 2));
+    userResourceConsumption2.put(
+        new UserIdentifier("tenant2", "name3"), new ResourceConsumption(3000, 3, 3000, 3));
 
     Map<String, DiskInfo> disks3 = new HashMap<>();
     disks3.put("disk1", new DiskInfo("disk1", 64 * 1024 * 1024 * 1024, 100, 0));
     disks3.put("disk2", new DiskInfo("disk2", 64 * 1024 * 1024 * 1024, 100, 0));
     disks3.put("disk3", new DiskInfo("disk3", 64 * 1024 * 1024 * 1024, 100, 0));
+    Map<UserIdentifier, ResourceConsumption> userResourceConsumption3 = new ConcurrentHashMap<>();
+    userResourceConsumption3.put(
+        new UserIdentifier("tenant3", "name1"), new ResourceConsumption(1000, 1, 1000, 1));
+    userResourceConsumption3.put(
+        new UserIdentifier("tenant3", "name2"), new ResourceConsumption(2000, 2, 2000, 2));
+    userResourceConsumption3.put(
+        new UserIdentifier("tenant3", "name3"), new ResourceConsumption(3000, 3, 3000, 3));
 
-    WorkerInfo info1 = new WorkerInfo("host1", 1, 2, 3, 10, disks1, null);
-    WorkerInfo info2 = new WorkerInfo("host2", 4, 5, 6, 11, disks2, null);
-    WorkerInfo info3 = new WorkerInfo("host3", 7, 8, 9, 12, disks3, null);
+    WorkerInfo info1 = new WorkerInfo("host1", 1, 2, 3, 10, disks1, userResourceConsumption1, null);
+    WorkerInfo info2 = new WorkerInfo("host2", 4, 5, 6, 11, disks2, userResourceConsumption2, null);
+    WorkerInfo info3 = new WorkerInfo("host3", 7, 8, 9, 12, disks3, userResourceConsumption3, null);
 
     String host1 = "host1";
     String host2 = "host2";

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -345,13 +345,34 @@ public class RatisMasterStatusSystemSuiteJ {
 
     WorkerInfo workerInfo1 =
         new WorkerInfo(
-            HOSTNAME1, RPCPORT1, PUSHPORT1, FETCHPORT1, REPLICATEPORT1, disks1, dummyRef);
+            HOSTNAME1,
+            RPCPORT1,
+            PUSHPORT1,
+            FETCHPORT1,
+            REPLICATEPORT1,
+            disks1,
+            userResourceConsumption1,
+            dummyRef);
     WorkerInfo workerInfo2 =
         new WorkerInfo(
-            HOSTNAME2, RPCPORT2, PUSHPORT2, FETCHPORT2, REPLICATEPORT2, disks2, dummyRef);
+            HOSTNAME2,
+            RPCPORT2,
+            PUSHPORT2,
+            FETCHPORT2,
+            REPLICATEPORT2,
+            disks2,
+            userResourceConsumption2,
+            dummyRef);
     WorkerInfo workerInfo3 =
         new WorkerInfo(
-            HOSTNAME3, RPCPORT3, PUSHPORT3, FETCHPORT3, REPLICATEPORT3, disks3, dummyRef);
+            HOSTNAME3,
+            RPCPORT3,
+            PUSHPORT3,
+            FETCHPORT3,
+            REPLICATEPORT3,
+            disks3,
+            userResourceConsumption3,
+            dummyRef);
 
     Map<String, Map<String, Integer>> workersToAllocate = new HashMap<>();
     Map<String, Integer> allocation1 = new HashMap<>();
@@ -522,10 +543,24 @@ public class RatisMasterStatusSystemSuiteJ {
     Thread.sleep(3000L);
     WorkerInfo workerInfo1 =
         new WorkerInfo(
-            HOSTNAME1, RPCPORT1, PUSHPORT1, FETCHPORT1, REPLICATEPORT1, disks1, dummyRef);
+            HOSTNAME1,
+            RPCPORT1,
+            PUSHPORT1,
+            FETCHPORT1,
+            REPLICATEPORT1,
+            disks1,
+            userResourceConsumption1,
+            dummyRef);
     WorkerInfo workerInfo2 =
         new WorkerInfo(
-            HOSTNAME2, RPCPORT2, PUSHPORT2, FETCHPORT2, REPLICATEPORT2, disks2, dummyRef);
+            HOSTNAME2,
+            RPCPORT2,
+            PUSHPORT2,
+            FETCHPORT2,
+            REPLICATEPORT2,
+            disks2,
+            userResourceConsumption2,
+            dummyRef);
     Map<String, Map<String, Integer>> workersToAllocate = new HashMap<>();
     Map<String, Integer> allocations = new HashMap<>();
     allocations.put("disk1", 5);
@@ -582,10 +617,24 @@ public class RatisMasterStatusSystemSuiteJ {
 
     WorkerInfo workerInfo1 =
         new WorkerInfo(
-            HOSTNAME1, RPCPORT1, PUSHPORT1, FETCHPORT1, REPLICATEPORT1, disks1, dummyRef);
+            HOSTNAME1,
+            RPCPORT1,
+            PUSHPORT1,
+            FETCHPORT1,
+            REPLICATEPORT1,
+            disks1,
+            userResourceConsumption1,
+            dummyRef);
     WorkerInfo workerInfo2 =
         new WorkerInfo(
-            HOSTNAME2, RPCPORT2, PUSHPORT2, FETCHPORT2, REPLICATEPORT2, disks2, dummyRef);
+            HOSTNAME2,
+            RPCPORT2,
+            PUSHPORT2,
+            FETCHPORT2,
+            REPLICATEPORT2,
+            disks2,
+            userResourceConsumption2,
+            dummyRef);
 
     Map<String, Map<String, Integer>> workersToAllocate = new HashMap<>();
     Map<String, Integer> allocations = new HashMap<>();
@@ -794,10 +843,24 @@ public class RatisMasterStatusSystemSuiteJ {
 
     WorkerInfo workerInfo1 =
         new WorkerInfo(
-            HOSTNAME1, RPCPORT1, PUSHPORT1, FETCHPORT1, REPLICATEPORT1, disks1, dummyRef);
+            HOSTNAME1,
+            RPCPORT1,
+            PUSHPORT1,
+            FETCHPORT1,
+            REPLICATEPORT1,
+            disks1,
+            userResourceConsumption1,
+            dummyRef);
     WorkerInfo workerInfo2 =
         new WorkerInfo(
-            HOSTNAME2, RPCPORT2, PUSHPORT2, FETCHPORT2, REPLICATEPORT2, disks2, dummyRef);
+            HOSTNAME2,
+            RPCPORT2,
+            PUSHPORT2,
+            FETCHPORT2,
+            REPLICATEPORT2,
+            disks2,
+            userResourceConsumption2,
+            dummyRef);
 
     List<WorkerInfo> failedWorkers = new ArrayList<>();
     failedWorkers.add(workerInfo1);

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -151,7 +151,7 @@ private[celeborn] class Worker(
     diskInfos.put(diskInfo.mountPoint, diskInfo)
   }
 
-  // need to ensure storageManager has recovered fileinfos data before retrieve consumption
+  // need to ensure storageManager has recovered fileinfos data if enable graceful shutdown before retrieve consumption
   val userResourceConsumption = storageManager.userResourceConsumptionSnapshot().asJava
 
   val workerInfo =


### PR DESCRIPTION
### What changes were proposed in this pull request?
Move userResourceConsumption to WorkerInfo's parameter and format WorkerInfo's toString()

### Why are the changes needed?
Make its structure more reasonable, and reformat the string output to be more clear.

### What are the items that need reviewer attention?
1. Has modified the `hashCode()` method of WorkerInfo, because it doesn't look quite right before.
2. Output of `WorkerInfo.toString` when diskInfos and userResourceConsumption are not empty
   <img width="1410" alt="image" src="https://user-images.githubusercontent.com/30563796/195634640-ae4fb1c8-79d7-474c-adf1-6cbadeac19a3.png">
3. Output of `WorkerInfo.toString` when diskInfos and userResourceConsumption are empty
   <img width="439" alt="image" src="https://user-images.githubusercontent.com/30563796/195630561-15fd1e96-fc2b-48ee-8413-a78e034d5d03.png">

### Related issues.
#751 

### Related pull requests.


### How was this patch tested?


/cc @AngersZhuuuu 

/assign @main-reviewer
