### PR TITLE
[BUILD] Extract project.version to Maven Property

### DIFF
--- a/client-spark/common/pom.xml
+++ b/client-spark/common/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.celeborn</groupId>
     <artifactId>celeborn-parent_${scala.binary.version}</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>${project.version}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/client-spark/spark-2/pom.xml
+++ b/client-spark/spark-2/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.celeborn</groupId>
     <artifactId>celeborn-parent_${scala.binary.version}</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>${project.version}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/client-spark/spark-3/pom.xml
+++ b/client-spark/spark-3/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.celeborn</groupId>
     <artifactId>celeborn-parent_${scala.binary.version}</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>${project.version}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.celeborn</groupId>
     <artifactId>celeborn-parent_${scala.binary.version}</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>${project.version}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.celeborn</groupId>
     <artifactId>celeborn-parent_${scala.binary.version}</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>${project.version}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.celeborn</groupId>
     <artifactId>celeborn-parent_${scala.binary.version}</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>${project.version}</version>
   </parent>
 
   <artifactId>celeborn-master_${scala.binary.version}</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>org.apache.celeborn</groupId>
   <artifactId>celeborn-parent_${scala.binary.version}</artifactId>
-  <version>0.2.0-SNAPSHOT</version>
+  <version>${project.version}</version>
   <packaging>pom</packaging>
 
   <name>Celeborn Project Parent POM</name>
@@ -53,6 +53,7 @@
   </distributionManagement>
 
   <properties>
+    <project.version>0.2.0-SNAPSHOT</project.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.celeborn</groupId>
     <artifactId>celeborn-parent_${scala.binary.version}</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>${project.version}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tests/spark-it/pom.xml
+++ b/tests/spark-it/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.celeborn</groupId>
     <artifactId>celeborn-parent_${scala.binary.version}</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>${project.version}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.celeborn</groupId>
     <artifactId>celeborn-parent_${scala.binary.version}</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>${project.version}</version>
   </parent>
 
   <artifactId>celeborn-worker_${scala.binary.version}</artifactId>


### PR DESCRIPTION
# [BUG]/[FEATURE] title

### What changes were proposed in this pull request?

Simplify the project version management, and it's easy to overwrite by changing one placing in the root pom.xml or `build/mvn deploy -Dproject.version=$RELEASE_VERSION`

### Why are the changes needed?

I found that the usual way does not take effect, it may be caused by `flatten-maven-plugin`

`build/mvn versions:set -DnewVersion=$RELEASE_VERSION -DgenerateBackupPoms=false`

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
