### PR TITLE
[ISSUE-774][REFACTOR] Add cache to avoid redundant UserIdentifier object when recover fileinfo

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/util/PbSerDeUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/PbSerDeUtils.java
@@ -103,11 +103,11 @@ public class PbSerDeUtils {
     return builder.build();
   }
 
-  public static ConcurrentHashMap<String, FileInfo> fromPbFileInfoMap(byte[] data)
+  public static ConcurrentHashMap<String, FileInfo> fromPbFileInfoMap(
+      byte[] data, ConcurrentHashMap<String, UserIdentifier> cache)
       throws InvalidProtocolBufferException {
     PbFileInfoMap pbFileInfoMap = PbFileInfoMap.parseFrom(data);
     ConcurrentHashMap<String, FileInfo> fileInfoMap = new ConcurrentHashMap<>();
-    ConcurrentHashMap<String, UserIdentifier> cache = new ConcurrentHashMap<>();
     for (Map.Entry<String, PbFileInfo> entry : pbFileInfoMap.getValuesMap().entrySet()) {
       FileInfo fileInfo;
       PbUserIdentifier pbUserIdentifier = entry.getValue().getUserIdentifier();

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -193,6 +193,7 @@ final private[worker] class StorageManager(conf: RssConf, workerSource: Abstract
 
   private def reloadAndCleanFileInfos(db: DB): Unit = {
     if (db != null) {
+      val cache = new ConcurrentHashMap[String, UserIdentifier]()
       val itr = db.iterator
       itr.seek(SHUFFLE_KEY_PREFIX.getBytes(StandardCharsets.UTF_8))
       while (itr.hasNext) {
@@ -201,7 +202,7 @@ final private[worker] class StorageManager(conf: RssConf, workerSource: Abstract
         if (key.startsWith(SHUFFLE_KEY_PREFIX)) {
           val shuffleKey = parseDbShuffleKey(key)
           try {
-            val files = PbSerDeUtils.fromPbFileInfoMap(entry.getValue)
+            val files = PbSerDeUtils.fromPbFileInfoMap(entry.getValue, cache)
             logDebug(s"Reload DB: ${shuffleKey} -> ${files}")
             fileInfos.put(shuffleKey, files)
             db.delete(entry.getKey)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add cache to avoid redundant UserIdentifier object when recover fileinfo

### Why are the changes needed?
avoid generate redundant UserIdentifier object when restore fileinfo with graceful shutdown.

### What are the items that need reviewer attention?


### Related issues.
#774 

### Related pull requests.


### How was this patch tested?


/cc @AngersZhuuuu 

/assign @main-reviewer
