### PR TITLE
[ISSUE-773][BUG] WorkerInfos hashCode() should be consistent with equals()

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -270,7 +270,7 @@ class WorkerInfo(
   }
 
   override def hashCode(): Int = {
-    Objects.hashCode(host, rpcPort, pushPort, fetchPort)
+    Objects.hashCode(host, rpcPort, pushPort, fetchPort, replicatePort)
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
WorkerInfos hashCode() should be consistent with equals()

### Why are the changes needed?
Decrease the possibility of hash collision.

### What are the items that need reviewer attention?


### Related issues.
#773 

### Related pull requests.


### How was this patch tested?


/cc @AngersZhuuuu 

/assign @main-reviewer
