### PR TITLE
Auto generate configuration docs

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/internal/config/ConfigBuilder.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/internal/config/ConfigBuilder.scala
@@ -140,6 +140,7 @@ class TypedConfigBuilder[T](
       stringConverter,
       parent._doc,
       parent._public,
+      parent._categories,
       parent._version)
     parent._onCreate.foreach(_(entry))
     entry
@@ -163,6 +164,7 @@ class TypedConfigBuilder[T](
           stringConverter,
           parent._doc,
           parent._public,
+          parent._categories,
           parent._version)
         parent._onCreate.foreach(_(entry))
         entry
@@ -181,6 +183,7 @@ class TypedConfigBuilder[T](
       stringConverter,
       parent._doc,
       parent._public,
+      parent._categories,
       parent._version)
     parent._onCreate.foreach(_(entry))
     entry
@@ -201,6 +204,7 @@ class TypedConfigBuilder[T](
       stringConverter,
       parent._doc,
       parent._public,
+      parent._categories,
       parent._version)
     parent._onCreate.foreach(_(entry))
     entry
@@ -308,6 +312,7 @@ case class ConfigBuilder(key: String) {
       _alternatives,
       _doc,
       _public,
+      _categories,
       _version,
       fallback)
     _onCreate.foreach(_(entry))

--- a/common/src/main/scala/org/apache/celeborn/common/internal/config/ConfigEntry.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/internal/config/ConfigEntry.scala
@@ -81,6 +81,7 @@ abstract class ConfigEntry[T](
     val stringConverter: T => String,
     val doc: String,
     val isPublic: Boolean,
+    val categories: Seq[String],
     val version: String) {
 
   import ConfigEntry._
@@ -121,6 +122,7 @@ private class ConfigEntryWithDefault[T](
     stringConverter: T => String,
     doc: String,
     isPublic: Boolean,
+    categories: Seq[String],
     version: String)
   extends ConfigEntry(
     key,
@@ -131,6 +133,7 @@ private class ConfigEntryWithDefault[T](
     stringConverter,
     doc,
     isPublic,
+    categories,
     version) {
 
   override def defaultValue: Option[T] = Some(_defaultValue)
@@ -152,6 +155,7 @@ private class ConfigEntryWithDefaultFunction[T](
     stringConverter: T => String,
     doc: String,
     isPublic: Boolean,
+    categories: Seq[String],
     version: String)
   extends ConfigEntry(
     key,
@@ -162,6 +166,7 @@ private class ConfigEntryWithDefaultFunction[T](
     stringConverter,
     doc,
     isPublic,
+    categories,
     version) {
 
   override def defaultValue: Option[T] = Some(_defaultFunction())
@@ -183,6 +188,7 @@ private class ConfigEntryWithDefaultString[T](
     stringConverter: T => String,
     doc: String,
     isPublic: Boolean,
+    categories: Seq[String],
     version: String)
   extends ConfigEntry(
     key,
@@ -193,6 +199,7 @@ private class ConfigEntryWithDefaultString[T](
     stringConverter,
     doc,
     isPublic,
+    categories,
     version) {
 
   override def defaultValue: Option[T] = Some(valueConverter(_defaultValue))
@@ -217,6 +224,7 @@ class OptionalConfigEntry[T](
     val rawStringConverter: T => String,
     doc: String,
     isPublic: Boolean,
+    categories: Seq[String],
     version: String)
   extends ConfigEntry[Option[T]](
     key,
@@ -227,6 +235,7 @@ class OptionalConfigEntry[T](
     v => v.map(rawStringConverter).orNull,
     doc,
     isPublic,
+    categories,
     version) {
 
   override def defaultValueString: String = ConfigEntry.UNDEFINED
@@ -246,6 +255,7 @@ class FallbackConfigEntry[T](
     alternatives: List[String],
     doc: String,
     isPublic: Boolean,
+    categories: Seq[String],
     version: String,
     val fallback: ConfigEntry[T])
   extends ConfigEntry[T](
@@ -257,6 +267,7 @@ class FallbackConfigEntry[T](
     fallback.stringConverter,
     doc,
     isPublic,
+    categories,
     version) {
 
   override def defaultValueString: String = s"<value of ${fallback.key}>"

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -535,6 +535,10 @@ object Utils extends Logging {
     // scalastyle:on classforname
   }
 
+  def getCodeSourceLocation(clazz: Class[_]): String = {
+    new File(clazz.getProtectionDomain.getCodeSource.getLocation.toURI).getPath
+  }
+
   def loadDefaultRssProperties(conf: RssConf, filePath: String = null): String = {
     val path = Option(filePath).getOrElse(getDefaultPropertiesFile())
     Option(path).foreach { confFile =>

--- a/common/src/test/scala/org/apache/celeborn/ConfigurationSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/ConfigurationSuite.scala
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path, Paths, StandardOpenOption}
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.celeborn.common.RssConf
+import org.apache.celeborn.common.internal.config.ConfigEntry
+import org.apache.celeborn.common.util.Utils
+
+/**
+ * End-to-end test cases for configuration documentation.
+ *
+ * The golden result file is "docs/configuration/".
+ *
+ * To run the entire test suite:
+ * {{{
+ *   build/mvn test -pl common -am -Pspark-3.3 -Dtest=none -DwildcardSuites=org.apache.celeborn.ConfigurationSuite
+ * }}}
+ *
+ * To re-generate golden files for entire suite, run:
+ * {{{
+ *   UPDATE=1 build/mvn test -pl common -am -Pspark-3.3 -Dtest=none -DwildcardSuites=org.apache.celeborn.ConfigurationSuite
+ * }}}
+ */
+class ConfigurationSuite extends AnyFunSuite {
+
+  val confEntries: Seq[ConfigEntry[_]] = RssConf.confEntries.values.asScala.toSeq
+
+  val confMarkdownDir: Path = Paths
+    .get(Utils.getCodeSourceLocation(getClass).split("common/target").head)
+    .resolve("docs")
+    .resolve("configuration")
+    .normalize
+
+  test("docs - configuration/client.md") {
+    generateConfigurationMarkdown("client")
+  }
+
+  test("docs - configuration/master.md") {
+    generateConfigurationMarkdown("master")
+  }
+
+  test("docs - configuration/worker.md") {
+    generateConfigurationMarkdown("worker")
+  }
+
+  test("docs - configuration/metrics.md") {
+    generateConfigurationMarkdown("metrics")
+  }
+
+  def generateConfigurationMarkdown(category: String): Unit = {
+    val markdown = confMarkdownDir.resolve(s"$category.md")
+
+    val output = new ArrayBuffer[String]
+    appendLicenseHeader(output)
+    appendBeginInclude(output)
+    appendConfigurationTableHeader(output)
+
+    val categoryConfEntries = confEntries.filter(_.categories contains category)
+
+    categoryConfEntries
+      .filter(_.isPublic)
+      .sortBy(_.key)
+      .foreach { entry =>
+        val seq = Seq(
+          s"${entry.key}",
+          s"${entry.defaultValueString}",
+          s"${entry.doc}",
+          s"${entry.version}")
+        output += seq.mkString("| ", " | ", " | ")
+      }
+    appendEndInclude(output)
+
+    verifyOutput(markdown, output)
+  }
+
+  def appendLicenseHeader(output: ArrayBuffer[String]): Unit = {
+    output += "---"
+    output += "license: |"
+    output += "  Licensed under the Apache License, Version 2.0 (the \"License\");"
+    output += "  you may not use this file except in compliance with the License."
+    output += "  You may obtain a copy of the License at"
+    output += "  "
+    output += "      https://www.apache.org/licenses/LICENSE-2.0"
+    output += "  "
+    output += "  Unless required by applicable law or agreed to in writing, software"
+    output += "  distributed under the License is distributed on an \"AS IS\" BASIS,"
+    output += "  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied."
+    output += "  See the License for the specific language governing permissions and"
+    output += "  limitations under the License."
+    output += "---"
+    output += ""
+  }
+
+  def appendConfigurationTableHeader(output: ArrayBuffer[String]): Unit = {
+    output += "| Key | Default | Description | Since |"
+    output += "| --- | ------- | ----------- | ----- |"
+  }
+
+  def appendBeginInclude(output: ArrayBuffer[String]): Unit = {
+    output += "<!--begin-include-->"
+  }
+
+  def appendEndInclude(output: ArrayBuffer[String]): Unit = {
+    output += "<!--end-include-->"
+  }
+
+  def verifyOutput(goldenFile: Path, output: ArrayBuffer[String]): Unit =
+    if (System.getenv("UPDATE") == "1") {
+      val writer = Files.newBufferedWriter(
+        goldenFile,
+        StandardCharsets.UTF_8,
+        StandardOpenOption.TRUNCATE_EXISTING,
+        StandardOpenOption.CREATE)
+      try output.foreach { line =>
+        writer.write(line)
+        writer.newLine()
+      } finally writer.close()
+    } else {
+      val expected = Files.readAllLines(goldenFile).asScala
+      val updateCmd = "UPDATE=1 build/mvn test -pl common -am -Pspark-3.3 " +
+        "-Dtest=none -DwildcardSuites=org.apache.celeborn.ConfigurationSuite"
+
+      val hint =
+        s"""
+           |$goldenFile is out of date, please update the golden file with
+           |
+           |  $updateCmd
+           |
+           |>
+           |""".stripMargin
+      assert(output.size === expected.size, hint)
+
+      output.zip(expected).foreach { case (out, in) => assert(out === in, hint) }
+    }
+}

--- a/common/src/test/scala/org/apache/celeborn/ConfigurationSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/ConfigurationSuite.scala
@@ -86,7 +86,7 @@ class ConfigurationSuite extends AnyFunSuite {
       .foreach { entry =>
         val seq = Seq(
           s"${entry.key}",
-          s"${entry.defaultValueString}",
+          s"`${entry.defaultValueString}`",
           s"${entry.doc}",
           s"${entry.version}")
         output += seq.mkString("| ", " | ", " | ")

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -16,22 +16,22 @@ license: |
 <!--begin-include-->
 | Key | Default | Description | Since |
 | --- | ------- | ----------- | ----- |
-| celeborn.application.heartbeat.interval | 10s | Interval for client to send heartbeat message to master. |  | 
-| celeborn.fetch.maxReqsInFlight | 3 | Amount of in-flight chunk fetch request. |  | 
-| celeborn.fetch.timeout | 120s | Timeout for a task to fetch chunk. |  | 
-| celeborn.master.endpoints | <localhost>:9097 | Endpoints of master nodes for celeborn client to connect, allowed pattern is: `<host1>:<port1>[,<host2>:<port2>]*`, e.g. `clb1:9097,clb2:9098,clb3:9099`. If the port is omitted, 9097 will be used. | 0.2.0 | 
-| celeborn.push.buffer.initial.size | 8k |  |  | 
-| celeborn.push.buffer.max.size | 64k | Max size of reducer partition buffer memory for shuffle hash writer. The pushed data will be buffered in memory before sending to Celeborn worker. For performance consideration keep this buffer size higher than 32K. Example: If reducer amount is 2000, buffer size is 64K, then each task will consume up to `64KiB * 2000 = 125MiB` heap memory. |  | 
-| celeborn.push.maxReqsInFlight | 32 | Amount of Netty in-flight requests. The maximum memory is `celeborn.push.maxReqsInFlight` * `celeborn.push.buffer.max.size` * compression ratio(1 in worst case), default: 64Kib * 32 = 2Mib |  | 
-| celeborn.push.queue.capacity | 512 | Push buffer queue size for a task. The maximum memory is `celeborn.push.buffer.max.size` * `celeborn.push.queue.capacity`, default: 64KiB * 512 = 32MiB |  | 
-| celeborn.push.replicate.enabled | true | When true, Celeborn worker will replicate shuffle data to another Celeborn worker asynchronously to ensure the pushed shuffle data won't be lost after the node failure. | 0.2.0 | 
-| celeborn.rpc.maxParallelism | 1024 | Max parallelism of client on sending RPC requests. |  | 
-| celeborn.shuffle.chuck.size | 8m | Max chunk size of reducer's merged shuffle data. For example, if a reducer's shuffle data is 128M and the data will need 16 fetch chunk requests to fetch. |  | 
-| celeborn.shuffle.expired.interval | 60s | Interval for client to check expired shuffles. |  | 
-| celeborn.shuffle.register.maxRetries | 3 | Max retry times for client to register shuffle. |  | 
-| celeborn.shuffle.register.retryWait | 3s | Wait time before next retry if register shuffle failed. |  | 
-| celeborn.shuffle.writer.mode | hash | Celeborn supports the following kind of shuffle writers. 1. hash: hash-based shuffle writer works fine when shuffle partition count is normal; 2. sort: sort-based shuffle writer works fine when memory pressure is high or shuffle partition count it huge. | 0.2.0 | 
-| celeborn.slot.reserve.maxRetries | 3 | Max retry times for client to reserve slots. |  | 
-| celeborn.slot.reserve.retryWait | 3s | Wait time before next retry if reserve slots failed. |  | 
-| celeborn.worker.excluded.interval | 30s | Interval for client to refresh excluded worker list. |  | 
+| celeborn.application.heartbeat.interval | `10s` | Interval for client to send heartbeat message to master. |  | 
+| celeborn.fetch.maxReqsInFlight | `3` | Amount of in-flight chunk fetch request. |  | 
+| celeborn.fetch.timeout | `120s` | Timeout for a task to fetch chunk. |  | 
+| celeborn.master.endpoints | `<localhost>:9097` | Endpoints of master nodes for celeborn client to connect, allowed pattern is: `<host1>:<port1>[,<host2>:<port2>]*`, e.g. `clb1:9097,clb2:9098,clb3:9099`. If the port is omitted, 9097 will be used. | 0.2.0 | 
+| celeborn.push.buffer.initial.size | `8k` |  |  | 
+| celeborn.push.buffer.max.size | `64k` | Max size of reducer partition buffer memory for shuffle hash writer. The pushed data will be buffered in memory before sending to Celeborn worker. For performance consideration keep this buffer size higher than 32K. Example: If reducer amount is 2000, buffer size is 64K, then each task will consume up to `64KiB * 2000 = 125MiB` heap memory. |  | 
+| celeborn.push.maxReqsInFlight | `32` | Amount of Netty in-flight requests. The maximum memory is `celeborn.push.maxReqsInFlight` * `celeborn.push.buffer.max.size` * compression ratio(1 in worst case), default: 64Kib * 32 = 2Mib |  | 
+| celeborn.push.queue.capacity | `512` | Push buffer queue size for a task. The maximum memory is `celeborn.push.buffer.max.size` * `celeborn.push.queue.capacity`, default: 64KiB * 512 = 32MiB |  | 
+| celeborn.push.replicate.enabled | `true` | When true, Celeborn worker will replicate shuffle data to another Celeborn worker asynchronously to ensure the pushed shuffle data won't be lost after the node failure. | 0.2.0 | 
+| celeborn.rpc.maxParallelism | `1024` | Max parallelism of client on sending RPC requests. |  | 
+| celeborn.shuffle.chuck.size | `8m` | Max chunk size of reducer's merged shuffle data. For example, if a reducer's shuffle data is 128M and the data will need 16 fetch chunk requests to fetch. |  | 
+| celeborn.shuffle.expired.interval | `60s` | Interval for client to check expired shuffles. |  | 
+| celeborn.shuffle.register.maxRetries | `3` | Max retry times for client to register shuffle. |  | 
+| celeborn.shuffle.register.retryWait | `3s` | Wait time before next retry if register shuffle failed. |  | 
+| celeborn.shuffle.writer.mode | `hash` | Celeborn supports the following kind of shuffle writers. 1. hash: hash-based shuffle writer works fine when shuffle partition count is normal; 2. sort: sort-based shuffle writer works fine when memory pressure is high or shuffle partition count it huge. | 0.2.0 | 
+| celeborn.slot.reserve.maxRetries | `3` | Max retry times for client to reserve slots. |  | 
+| celeborn.slot.reserve.retryWait | `3s` | Wait time before next retry if reserve slots failed. |  | 
+| celeborn.worker.excluded.interval | `30s` | Interval for client to refresh excluded worker list. |  | 
 <!--end-include-->

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -1,0 +1,37 @@
+---
+license: |
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      https://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+<!--begin-include-->
+| Key | Default | Description | Since |
+| --- | ------- | ----------- | ----- |
+| celeborn.application.heartbeat.interval | 10s | Interval for client to send heartbeat message to master. |  | 
+| celeborn.fetch.maxReqsInFlight | 3 | Amount of in-flight chunk fetch request. |  | 
+| celeborn.fetch.timeout | 120s | Timeout for a task to fetch chunk. |  | 
+| celeborn.master.endpoints | <localhost>:9097 | Endpoints of master nodes for celeborn client to connect, allowed pattern is: `<host1>:<port1>[,<host2>:<port2>]*`, e.g. `clb1:9097,clb2:9098,clb3:9099`. If the port is omitted, 9097 will be used. | 0.2.0 | 
+| celeborn.push.buffer.initial.size | 8k |  |  | 
+| celeborn.push.buffer.max.size | 64k | Max size of reducer partition buffer memory for shuffle hash writer. The pushed data will be buffered in memory before sending to Celeborn worker. For performance consideration keep this buffer size higher than 32K. Example: If reducer amount is 2000, buffer size is 64K, then each task will consume up to `64KiB * 2000 = 125MiB` heap memory. |  | 
+| celeborn.push.maxReqsInFlight | 32 | Amount of Netty in-flight requests. The maximum memory is `celeborn.push.maxReqsInFlight` * `celeborn.push.buffer.max.size` * compression ratio(1 in worst case), default: 64Kib * 32 = 2Mib |  | 
+| celeborn.push.queue.capacity | 512 | Push buffer queue size for a task. The maximum memory is `celeborn.push.buffer.max.size` * `celeborn.push.queue.capacity`, default: 64KiB * 512 = 32MiB |  | 
+| celeborn.push.replicate.enabled | true | When true, Celeborn worker will replicate shuffle data to another Celeborn worker asynchronously to ensure the pushed shuffle data won't be lost after the node failure. | 0.2.0 | 
+| celeborn.rpc.maxParallelism | 1024 | Max parallelism of client on sending RPC requests. |  | 
+| celeborn.shuffle.chuck.size | 8m | Max chunk size of reducer's merged shuffle data. For example, if a reducer's shuffle data is 128M and the data will need 16 fetch chunk requests to fetch. |  | 
+| celeborn.shuffle.expired.interval | 60s | Interval for client to check expired shuffles. |  | 
+| celeborn.shuffle.register.maxRetries | 3 | Max retry times for client to register shuffle. |  | 
+| celeborn.shuffle.register.retryWait | 3s | Wait time before next retry if register shuffle failed. |  | 
+| celeborn.shuffle.writer.mode | hash | Celeborn supports the following kind of shuffle writers. 1. hash: hash-based shuffle writer works fine when shuffle partition count is normal; 2. sort: sort-based shuffle writer works fine when memory pressure is high or shuffle partition count it huge. | 0.2.0 | 
+| celeborn.slot.reserve.maxRetries | 3 | Max retry times for client to reserve slots. |  | 
+| celeborn.slot.reserve.retryWait | 3s | Wait time before next retry if reserve slots failed. |  | 
+| celeborn.worker.excluded.interval | 30s | Interval for client to refresh excluded worker list. |  | 
+<!--end-include-->

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1,0 +1,129 @@
+---
+hide:
+  - navigation
+
+license: |
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      https://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+Configuration Guide
+===
+This documentation contains Celeborn configuration details and a tuning guide.
+
+## Important Configurations
+
+### Environment Variables
+
+- `CELEBORN_WORKER_MEMORY=4g`
+- `CELEBORN_WORKER_OFFHEAP_MEMORY=24g`
+
+Celeborn workers tend to improve performance by using off-heap buffers.
+Off-heap memory requirement can be estimated as below:
+
+```
+numDirs = `celeborn.worker.storage.dirs`      # the amount of directory will be used by Celeborn storage
+bufferSize = `rss.worker.flush.buffer.size`   # the amount of memory will be used by a single flush buffer 
+off-heap-memory = bufferSize * estimatedTasks * 2 + network memory
+```
+
+For example, if an Celeborn worker has 10 storage directories or disks and the buffer size is set to 256 KiB.
+The necessary off-heap memory is 10 GiB.
+
+NetWork memory will be consumed when netty reads from a TPC channel, there will need some extra
+memory. Empirically, Celeborn worker off-heap memory should be set to `(numDirs  * bufferSize * 1.2)`.
+
+## All Configurations
+
+### Client
+
+{!
+include-markdown "./client.md"
+start="<!--begin-include-->"
+end="<!--end-include-->"
+!}
+
+### Master
+
+{!
+include-markdown "./master.md"
+start="<!--begin-include-->"
+end="<!--end-include-->"
+!}
+
+### Worker
+
+{!
+include-markdown "./worker.md"
+start="<!--begin-include-->"
+end="<!--end-include-->"
+!}
+
+### Metrics
+
+{!
+include-markdown "./metrics.md"
+start="<!--begin-include-->"
+end="<!--end-include-->"
+!}
+
+#### metrics.properties
+
+```properties
+*.sink.csv.class=org.apache.celeborn.common.metrics.sink.CsvSink
+*.sink.prometheusServlet.class=org.apache.celeborn.common.metrics.sink.PrometheusServlet
+```
+
+### Environment Variables
+
+Recommend configuring in `conf/celeborn-env.sh`.
+
+| Key                              | Default                                         | Description |
+|----------------------------------|-------------------------------------------------|-------------|
+| `CELEBORN_HOME`                  | ``$(cd "`dirname "$0"`"/..; pwd)``              |             |
+| `CELEBORN_CONF_DIR`              | `${CELEBORN_CONF_DIR:-"${CELEBORN_HOME}/conf"}` |             |
+| `CELEBORN_MASTER_MEMORY`         | 1 GB                                            |             |
+| `CELEBORN_WORKER_MEMORY`         | 1 GB                                            |             |
+| `CELEBORN_WORKER_OFFHEAP_MEMORY` | 1 GB                                            |             |
+| `CELEBORN_MASTER_JAVA_OPTS`      |                                                 |             |
+| `CELEBORN_WORKER_JAVA_OPTS`      |                                                 |             |
+| `CELEBORN_PID_DIR`               | `${CELEBORN_HOME}/pids`                         |             |
+| `CELEBORN_LOG_DIR`               | `${CELEBORN_HOME}/logs`                         |             |
+| `CELEBORN_SSH_OPTS`              | `-o StrictHostKeyChecking=no`                   |             |
+| `CELEBORN_SLEEP`                 |                                                 |             |
+
+## Tuning
+
+Assume we have a cluster described as below:
+5 Celeborn Workers with 20 GB off-heap memory and 10 disks.
+As we need to reserve 20% off-heap memory for netty,
+so we could assume 16 GB off-heap memory can be used for flush buffers.
+
+If `spark.celeborn.push.buffer.size` is 64 KB, we can have in-flight requests up to 1310720.
+If you have 8192 mapper tasks, you could set `spark.celeborn.push.maxReqsInFlight=160` to gain performance improvements.
+
+If `celeborn.worker.flush.buffer.size` is 256 KB, we can have total slots up to 327680 slots.
+
+## Worker Recover Status After Restart
+
+`ShuffleClient` records the shuffle partition location's host, service port, and filename,
+to support workers recovering reading existing shuffle data after worker restart,
+during worker shutdown, workers should store the meta about reading shuffle partition files in LevelDB,
+and restore the meta after restarting workers, also workers should keep a stable service port to support
+`ShuffleClient` retry reading data. Users should set `rss.worker.graceful.shutdown` to `true` and
+set below service port with stable port to support worker recover status.
+```
+rss.worker.rpc.port
+rss.fetchserver.port
+rss.pushserver.port
+rss.replicateserver.port
+```

--- a/docs/configuration/master.md
+++ b/docs/configuration/master.md
@@ -16,20 +16,20 @@ license: |
 <!--begin-include-->
 | Key | Default | Description | Since |
 | --- | ------- | ----------- | ----- |
-| celeborn.application.heartbeat.timeout | 120s | Application heartbeat timeout. |  | 
-| celeborn.ha.enabled | false | When true, master nodes run as Raft cluster mode. | 0.1.0 | 
-| celeborn.ha.master.node.<id>.host | <required> | Host to bind of master node <id> in HA mode. | 0.2.0 | 
-| celeborn.ha.master.node.<id>.port | 9097 | Port to bind of master node <id> in HA mode. | 0.2.0 | 
-| celeborn.ha.master.node.<id>.ratis.port | 9872 | Ratis port to bind of master node <id> in HA mode. | 0.2.0 | 
-| celeborn.ha.master.ratis.raft.rpc.type | netty | RPC type for Ratis, available options: netty, grpc. | 0.2.0 | 
-| celeborn.ha.master.ratis.raft.server.storage.dir | /tmp/ratis |  | 0.2.0 | 
-| celeborn.master.host | <localhost> | Hostname for master to bind. | 0.2.0 | 
-| celeborn.master.metrics.prometheus.host | 0.0.0.0 |  |  | 
-| celeborn.master.metrics.prometheus.port | 9098 |  |  | 
-| celeborn.master.port | 9097 | Port for master to bind. | 0.2.0 | 
-| celeborn.metrics.enabled | true | When true, enable metrics system. |  | 
-| celeborn.metrics.sample.rate | 1.0 |  |  | 
-| celeborn.metrics.timer.sliding.size | 4000 |  |  | 
-| celeborn.metrics.timer.sliding.window.size | 4096 |  |  | 
-| celeborn.worker.heartbeat.timeout | 120s | Worker heartbeat timeout. |  | 
+| celeborn.application.heartbeat.timeout | `120s` | Application heartbeat timeout. |  | 
+| celeborn.ha.enabled | `false` | When true, master nodes run as Raft cluster mode. | 0.1.0 | 
+| celeborn.ha.master.node.<id>.host | `<required>` | Host to bind of master node <id> in HA mode. | 0.2.0 | 
+| celeborn.ha.master.node.<id>.port | `9097` | Port to bind of master node <id> in HA mode. | 0.2.0 | 
+| celeborn.ha.master.node.<id>.ratis.port | `9872` | Ratis port to bind of master node <id> in HA mode. | 0.2.0 | 
+| celeborn.ha.master.ratis.raft.rpc.type | `netty` | RPC type for Ratis, available options: netty, grpc. | 0.2.0 | 
+| celeborn.ha.master.ratis.raft.server.storage.dir | `/tmp/ratis` |  | 0.2.0 | 
+| celeborn.master.host | `<localhost>` | Hostname for master to bind. | 0.2.0 | 
+| celeborn.master.metrics.prometheus.host | `0.0.0.0` |  |  | 
+| celeborn.master.metrics.prometheus.port | `9098` |  |  | 
+| celeborn.master.port | `9097` | Port for master to bind. | 0.2.0 | 
+| celeborn.metrics.enabled | `true` | When true, enable metrics system. |  | 
+| celeborn.metrics.sample.rate | `1.0` |  |  | 
+| celeborn.metrics.timer.sliding.size | `4000` |  |  | 
+| celeborn.metrics.timer.sliding.window.size | `4096` |  |  | 
+| celeborn.worker.heartbeat.timeout | `120s` | Worker heartbeat timeout. |  | 
 <!--end-include-->

--- a/docs/configuration/master.md
+++ b/docs/configuration/master.md
@@ -1,0 +1,35 @@
+---
+license: |
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      https://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+<!--begin-include-->
+| Key | Default | Description | Since |
+| --- | ------- | ----------- | ----- |
+| celeborn.application.heartbeat.timeout | 120s | Application heartbeat timeout. |  | 
+| celeborn.ha.enabled | false | When true, master nodes run as Raft cluster mode. | 0.1.0 | 
+| celeborn.ha.master.node.<id>.host | <required> | Host to bind of master node <id> in HA mode. | 0.2.0 | 
+| celeborn.ha.master.node.<id>.port | 9097 | Port to bind of master node <id> in HA mode. | 0.2.0 | 
+| celeborn.ha.master.node.<id>.ratis.port | 9872 | Ratis port to bind of master node <id> in HA mode. | 0.2.0 | 
+| celeborn.ha.master.ratis.raft.rpc.type | netty | RPC type for Ratis, available options: netty, grpc. | 0.2.0 | 
+| celeborn.ha.master.ratis.raft.server.storage.dir | /tmp/ratis |  | 0.2.0 | 
+| celeborn.master.host | <localhost> | Hostname for master to bind. | 0.2.0 | 
+| celeborn.master.metrics.prometheus.host | 0.0.0.0 |  |  | 
+| celeborn.master.metrics.prometheus.port | 9098 |  |  | 
+| celeborn.master.port | 9097 | Port for master to bind. | 0.2.0 | 
+| celeborn.metrics.enabled | true | When true, enable metrics system. |  | 
+| celeborn.metrics.sample.rate | 1.0 |  |  | 
+| celeborn.metrics.timer.sliding.size | 4000 |  |  | 
+| celeborn.metrics.timer.sliding.window.size | 4096 |  |  | 
+| celeborn.worker.heartbeat.timeout | 120s | Worker heartbeat timeout. |  | 
+<!--end-include-->

--- a/docs/configuration/metrics.md
+++ b/docs/configuration/metrics.md
@@ -16,12 +16,12 @@ license: |
 <!--begin-include-->
 | Key | Default | Description | Since |
 | --- | ------- | ----------- | ----- |
-| celeborn.master.metrics.prometheus.host | 0.0.0.0 |  |  | 
-| celeborn.master.metrics.prometheus.port | 9098 |  |  | 
-| celeborn.metrics.enabled | true | When true, enable metrics system. |  | 
-| celeborn.metrics.sample.rate | 1.0 |  |  | 
-| celeborn.metrics.timer.sliding.size | 4000 |  |  | 
-| celeborn.metrics.timer.sliding.window.size | 4096 |  |  | 
-| celeborn.worker.metrics.prometheus.host | 0.0.0.0 |  |  | 
-| celeborn.worker.metrics.prometheus.port | 9096 |  |  | 
+| celeborn.master.metrics.prometheus.host | `0.0.0.0` |  |  | 
+| celeborn.master.metrics.prometheus.port | `9098` |  |  | 
+| celeborn.metrics.enabled | `true` | When true, enable metrics system. |  | 
+| celeborn.metrics.sample.rate | `1.0` |  |  | 
+| celeborn.metrics.timer.sliding.size | `4000` |  |  | 
+| celeborn.metrics.timer.sliding.window.size | `4096` |  |  | 
+| celeborn.worker.metrics.prometheus.host | `0.0.0.0` |  |  | 
+| celeborn.worker.metrics.prometheus.port | `9096` |  |  | 
 <!--end-include-->

--- a/docs/configuration/metrics.md
+++ b/docs/configuration/metrics.md
@@ -1,0 +1,27 @@
+---
+license: |
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      https://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+<!--begin-include-->
+| Key | Default | Description | Since |
+| --- | ------- | ----------- | ----- |
+| celeborn.master.metrics.prometheus.host | 0.0.0.0 |  |  | 
+| celeborn.master.metrics.prometheus.port | 9098 |  |  | 
+| celeborn.metrics.enabled | true | When true, enable metrics system. |  | 
+| celeborn.metrics.sample.rate | 1.0 |  |  | 
+| celeborn.metrics.timer.sliding.size | 4000 |  |  | 
+| celeborn.metrics.timer.sliding.window.size | 4096 |  |  | 
+| celeborn.worker.metrics.prometheus.host | 0.0.0.0 |  |  | 
+| celeborn.worker.metrics.prometheus.port | 9096 |  |  | 
+<!--end-include-->

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -30,5 +30,5 @@ license: |
 | celeborn.worker.metrics.prometheus.host | 0.0.0.0 |  |  | 
 | celeborn.worker.metrics.prometheus.port | 9096 |  |  | 
 | celeborn.worker.replicate.threads | 64 | Thread number of worker to replicate shuffle data. |  | 
-| celeborn.worker.storage.dirs | <undefined> | Directory list to store shuffle data. Storage size limit can be set for each flush thread. For the sake of performance, there should be no more than 2 directories on the same disk partition if you are using HDD. There can be 4 or more directories can run on the same disk partition if you are using SSD. For example: dir1[:capacity=][:disktype=][:flushthread=],dir2[:capacity=][:disktype=][:flushthread=] |  | 
+| celeborn.worker.storage.dirs | <undefined> | Directory list to store shuffle data. It's recommended to configure one directory on each disk. Storage size limit can be set for each directory. For the sake of performance, there should be no more than 2 flush threads on the same disk partition if you are using HDD, and should be 8 or more flush threads on the same disk partition if you are using SSD. For example: dir1[:capacity=][:disktype=][:flushthread=],dir2[:capacity=][:disktype=][:flushthread=] |  | 
 <!--end-include-->

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -1,0 +1,34 @@
+---
+license: |
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      https://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+<!--begin-include-->
+| Key | Default | Description | Since |
+| --- | ------- | ----------- | ----- |
+| celeborn.master.endpoints | <localhost>:9097 | Endpoints of master nodes for celeborn client to connect, allowed pattern is: `<host1>:<port1>[,<host2>:<port2>]*`, e.g. `clb1:9097,clb2:9098,clb3:9099`. If the port is omitted, 9097 will be used. | 0.2.0 | 
+| celeborn.metrics.enabled | true | When true, enable metrics system. |  | 
+| celeborn.metrics.sample.rate | 1.0 |  |  | 
+| celeborn.metrics.timer.sliding.size | 4000 |  |  | 
+| celeborn.metrics.timer.sliding.window.size | 4096 |  |  | 
+| celeborn.shuffle.chuck.size | 8m | Max chunk size of reducer's merged shuffle data. For example, if a reducer's shuffle data is 128M and the data will need 16 fetch chunk requests to fetch. |  | 
+| celeborn.worker.commit.threads | 32 | Thread number of worker to commit shuffle data files asynchronously. |  | 
+| celeborn.worker.deviceMonitor.checklist | readwrite,diskusage | Select what the device needs to detect, available items are: iohang, readwrite and diskusage. |  | 
+| celeborn.worker.deviceMonitor.enabled | true | When true, worker will monitor device and report to master. |  | 
+| celeborn.worker.flush.buffer.size | 256k | Size of buffer used by a single flusher. |  | 
+| celeborn.worker.heartbeat.timeout | 120s | Worker heartbeat timeout. |  | 
+| celeborn.worker.metrics.prometheus.host | 0.0.0.0 |  |  | 
+| celeborn.worker.metrics.prometheus.port | 9096 |  |  | 
+| celeborn.worker.replicate.threads | 64 | Thread number of worker to replicate shuffle data. |  | 
+| celeborn.worker.storage.dirs | <undefined> | Directory list to store shuffle data. Storage size limit can be set for each flush thread. For the sake of performance, there should be no more than 2 directories on the same disk partition if you are using HDD. There can be 4 or more directories can run on the same disk partition if you are using SSD. For example: dir1[:capacity=][:disktype=][:flushthread=],dir2[:capacity=][:disktype=][:flushthread=] |  | 
+<!--end-include-->

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -16,19 +16,19 @@ license: |
 <!--begin-include-->
 | Key | Default | Description | Since |
 | --- | ------- | ----------- | ----- |
-| celeborn.master.endpoints | <localhost>:9097 | Endpoints of master nodes for celeborn client to connect, allowed pattern is: `<host1>:<port1>[,<host2>:<port2>]*`, e.g. `clb1:9097,clb2:9098,clb3:9099`. If the port is omitted, 9097 will be used. | 0.2.0 | 
-| celeborn.metrics.enabled | true | When true, enable metrics system. |  | 
-| celeborn.metrics.sample.rate | 1.0 |  |  | 
-| celeborn.metrics.timer.sliding.size | 4000 |  |  | 
-| celeborn.metrics.timer.sliding.window.size | 4096 |  |  | 
-| celeborn.shuffle.chuck.size | 8m | Max chunk size of reducer's merged shuffle data. For example, if a reducer's shuffle data is 128M and the data will need 16 fetch chunk requests to fetch. |  | 
-| celeborn.worker.commit.threads | 32 | Thread number of worker to commit shuffle data files asynchronously. |  | 
-| celeborn.worker.deviceMonitor.checklist | readwrite,diskusage | Select what the device needs to detect, available items are: iohang, readwrite and diskusage. |  | 
-| celeborn.worker.deviceMonitor.enabled | true | When true, worker will monitor device and report to master. |  | 
-| celeborn.worker.flush.buffer.size | 256k | Size of buffer used by a single flusher. |  | 
-| celeborn.worker.heartbeat.timeout | 120s | Worker heartbeat timeout. |  | 
-| celeborn.worker.metrics.prometheus.host | 0.0.0.0 |  |  | 
-| celeborn.worker.metrics.prometheus.port | 9096 |  |  | 
-| celeborn.worker.replicate.threads | 64 | Thread number of worker to replicate shuffle data. |  | 
-| celeborn.worker.storage.dirs | <undefined> | Directory list to store shuffle data. It's recommended to configure one directory on each disk. Storage size limit can be set for each directory. For the sake of performance, there should be no more than 2 flush threads on the same disk partition if you are using HDD, and should be 8 or more flush threads on the same disk partition if you are using SSD. For example: dir1[:capacity=][:disktype=][:flushthread=],dir2[:capacity=][:disktype=][:flushthread=] |  | 
+| celeborn.master.endpoints | `<localhost>:9097` | Endpoints of master nodes for celeborn client to connect, allowed pattern is: `<host1>:<port1>[,<host2>:<port2>]*`, e.g. `clb1:9097,clb2:9098,clb3:9099`. If the port is omitted, 9097 will be used. | 0.2.0 | 
+| celeborn.metrics.enabled | `true` | When true, enable metrics system. |  | 
+| celeborn.metrics.sample.rate | `1.0` |  |  | 
+| celeborn.metrics.timer.sliding.size | `4000` |  |  | 
+| celeborn.metrics.timer.sliding.window.size | `4096` |  |  | 
+| celeborn.shuffle.chuck.size | `8m` | Max chunk size of reducer's merged shuffle data. For example, if a reducer's shuffle data is 128M and the data will need 16 fetch chunk requests to fetch. |  | 
+| celeborn.worker.commit.threads | `32` | Thread number of worker to commit shuffle data files asynchronously. |  | 
+| celeborn.worker.deviceMonitor.checklist | `readwrite,diskusage` | Select what the device needs to detect, available items are: iohang, readwrite and diskusage. |  | 
+| celeborn.worker.deviceMonitor.enabled | `true` | When true, worker will monitor device and report to master. |  | 
+| celeborn.worker.flush.buffer.size | `256k` | Size of buffer used by a single flusher. |  | 
+| celeborn.worker.heartbeat.timeout | `120s` | Worker heartbeat timeout. |  | 
+| celeborn.worker.metrics.prometheus.host | `0.0.0.0` |  |  | 
+| celeborn.worker.metrics.prometheus.port | `9096` |  |  | 
+| celeborn.worker.replicate.threads | `64` | Thread number of worker to replicate shuffle data. |  | 
+| celeborn.worker.storage.dirs | `<undefined>` | Directory list to store shuffle data. It's recommended to configure one directory on each disk. Storage size limit can be set for each directory. For the sake of performance, there should be no more than 2 flush threads on the same disk partition if you are using HDD, and should be 8 or more flush threads on the same disk partition if you are using SSD. For example: dir1[:capacity=][:disktype=][:flushthread=],dir2[:capacity=][:disktype=][:flushthread=] |  | 
 <!--end-include-->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,13 +15,16 @@
 # limitations under the License.
 #
 
-site_name: Celeborn
-repo_name: alibaba/celeborn
-repo_url: https://github.com/alibaba/celeborn
+site_name: Apache Celeborn (Incubating)
+repo_name: apache/incubating-celeborn
+repo_url: https://github.com/apache/incubating-celeborn
 
 plugins:
   - search
   - macros
+  - include-markdown:
+      opening_tag: "{!"
+      closing_tag: "!}"
 
 theme:
   name: material
@@ -48,6 +51,6 @@ extra:
 nav:
   - Home: index.md
   - Configuration:
-      - configuration.md
+      - configuration/index.md
   - Contributor:
       - Docs and Website: contrib/docs_and_website.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ Markdown==3.3.7
 MarkupSafe==2.1.1
 mergedeep==1.3.4
 mkdocs==1.3.1
+mkdocs-include-markdown-plugin==3.8.1
 mkdocs-macros-plugin==0.7.0
 mkdocs-material==8.3.9
 mkdocs-material-extensions==1.0.3


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR introduces a test suite to generate markdown files for `ConfigEntry`s and treats `docs/configuration/*.md` as golden files.

The golden files can be generated by

```
UPDATE=1 build/mvn test -pl common -am -Pspark-3.3 -Dtest=none -DwildcardSuites=org.apache.celeborn.ConfigurationSuite
```

UT will fail if the contributor updated the configuration code but forgot to re-generate docs.

<img width="877" alt="image" src="https://user-images.githubusercontent.com/26535726/196511134-f60c527d-163a-4b6d-bd96-6bc7e7502145.png">

Site previews

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/26535726/196512032-7a0f9bc5-2078-4e11-972f-cb59132e480d.png">
<img width="1724" alt="image" src="https://user-images.githubusercontent.com/26535726/196512090-7e7918d8-0874-471a-8662-2c088d882252.png">


### Why are the changes needed?

Reduce configuration documentation maintenance effort, and keep the documentation consistent w/ code.

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
