### PR TITLE
[MINOR] Use rssConf instead of sparkConf to avoid unnecessary parsing to generate rssConf.

### DIFF
--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
@@ -56,7 +56,7 @@ public class RssShuffleManager implements ShuffleManager {
     this.conf = conf;
     this.rssConf = SparkUtils.fromSparkConf(conf);
     this.cores = conf.getInt(SparkLauncher.EXECUTOR_CORES, 1);
-    this.fallbackPolicyRunner = new RssShuffleFallbackPolicyRunner(conf);
+    this.fallbackPolicyRunner = new RssShuffleFallbackPolicyRunner(rssConf);
   }
 
   private boolean isDriver() {

--- a/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleFallbackPolicyRunner.scala
+++ b/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleFallbackPolicyRunner.scala
@@ -17,15 +17,11 @@
 
 package org.apache.spark.shuffle.celeborn
 
-import org.apache.spark.SparkConf
-
 import org.apache.celeborn.client.LifecycleManager
 import org.apache.celeborn.common.RssConf
 import org.apache.celeborn.common.internal.Logging
 
-class RssShuffleFallbackPolicyRunner(sparkConf: SparkConf) extends Logging {
-
-  private lazy val rssConf = SparkUtils.fromSparkConf(sparkConf)
+class RssShuffleFallbackPolicyRunner(rssConf: RssConf) extends Logging {
 
   def applyAllFallbackPolicy(lifecycleManager: LifecycleManager, numPartitions: Int): Boolean = {
     applyForceFallbackPolicy() || applyShufflePartitionsFallbackPolicy(numPartitions) ||

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
@@ -54,7 +54,7 @@ public class RssShuffleManager implements ShuffleManager {
     this.conf = conf;
     this.rssConf = SparkUtils.fromSparkConf(conf);
     this.cores = conf.getInt(SparkLauncher.EXECUTOR_CORES, 1);
-    this.fallbackPolicyRunner = new RssShuffleFallbackPolicyRunner(conf);
+    this.fallbackPolicyRunner = new RssShuffleFallbackPolicyRunner(rssConf);
   }
 
   private boolean isDriver() {

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleFallbackPolicyRunner.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleFallbackPolicyRunner.scala
@@ -17,15 +17,11 @@
 
 package org.apache.spark.shuffle.celeborn
 
-import org.apache.spark.SparkConf
-
 import org.apache.celeborn.client.LifecycleManager
 import org.apache.celeborn.common.RssConf
 import org.apache.celeborn.common.internal.Logging
 
-class RssShuffleFallbackPolicyRunner(sparkConf: SparkConf) extends Logging {
-
-  private lazy val rssConf = SparkUtils.fromSparkConf(sparkConf)
+class RssShuffleFallbackPolicyRunner(rssConf: RssConf) extends Logging {
 
   def applyAllFallbackPolicy(lifecycleManager: LifecycleManager, numPartitions: Int): Boolean = {
     applyForceFallbackPolicy() || applyShufflePartitionsFallbackPolicy(numPartitions) ||


### PR DESCRIPTION
# [BUG]/[FEATURE] title

### What changes were proposed in this pull request?

Use rssConf instead of sparkConf to avoid unnecessary parsing to generate rssConf.

### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
