### PR TITLE
[ISSUE-805][REFACTOR] Remove UserIdentifier out of ControlMessage

### DIFF
--- a/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleHandle.scala
+++ b/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleHandle.scala
@@ -20,7 +20,7 @@ package org.apache.spark.shuffle.celeborn
 import org.apache.spark.ShuffleDependency
 import org.apache.spark.shuffle.BaseShuffleHandle
 
-import org.apache.celeborn.common.protocol.message.ControlMessages.UserIdentifier
+import org.apache.celeborn.common.identity.UserIdentifier
 
 class RssShuffleHandle[K, V, C](
     val newAppId: String,

--- a/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/RssShuffleWriterSuiteJ.java
+++ b/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/RssShuffleWriterSuiteJ.java
@@ -75,8 +75,8 @@ import org.slf4j.LoggerFactory;
 import org.apache.celeborn.client.DummyShuffleClient;
 import org.apache.celeborn.client.ShuffleClient;
 import org.apache.celeborn.common.RssConf;
+import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.network.util.JavaUtils;
-import org.apache.celeborn.common.protocol.message.ControlMessages;
 import org.apache.celeborn.common.util.Utils;
 
 public class RssShuffleWriterSuiteJ {
@@ -91,8 +91,7 @@ public class RssShuffleWriterSuiteJ {
   private final String host = "host";
   private final int port = 0;
 
-  private final ControlMessages.UserIdentifier userIdentifier =
-      new ControlMessages.UserIdentifier("mock", "mock");
+  private final UserIdentifier userIdentifier = new UserIdentifier("mock", "mock");
 
   private final int shuffleId = 0;
   private final int numMaps = 10;

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleHandle.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleHandle.scala
@@ -20,7 +20,7 @@ package org.apache.spark.shuffle.celeborn
 import org.apache.spark.ShuffleDependency
 import org.apache.spark.shuffle.BaseShuffleHandle
 
-import org.apache.celeborn.common.protocol.message.ControlMessages.UserIdentifier
+import org.apache.celeborn.common.identity.UserIdentifier
 
 class RssShuffleHandle[K, V, C](
     val newAppId: String,

--- a/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/RssShuffleWriterSuiteJ.java
+++ b/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/RssShuffleWriterSuiteJ.java
@@ -73,8 +73,8 @@ import org.slf4j.LoggerFactory;
 import org.apache.celeborn.client.DummyShuffleClient;
 import org.apache.celeborn.client.ShuffleClient;
 import org.apache.celeborn.common.RssConf;
+import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.network.util.JavaUtils;
-import org.apache.celeborn.common.protocol.message.ControlMessages;
 import org.apache.celeborn.common.util.Utils;
 
 public class RssShuffleWriterSuiteJ {
@@ -90,8 +90,7 @@ public class RssShuffleWriterSuiteJ {
   private final int port = 0;
   private final int shuffleId = 0;
 
-  private final ControlMessages.UserIdentifier userIdentifier =
-      new ControlMessages.UserIdentifier("mock", "mock");
+  private final UserIdentifier userIdentifier = new UserIdentifier("mock", "mock");
 
   private final int numMaps = 10;
   private final int numPartitions = 10;

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.fs.FileSystem;
 
 import org.apache.celeborn.client.read.RssInputStream;
 import org.apache.celeborn.common.RssConf;
-import org.apache.celeborn.common.protocol.message.ControlMessages.UserIdentifier;
+import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.rpc.RpcEndpointRef;
 
 /**

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -41,6 +41,7 @@ import org.apache.celeborn.client.write.DataBatches;
 import org.apache.celeborn.client.write.PushState;
 import org.apache.celeborn.common.RssConf;
 import org.apache.celeborn.common.haclient.RssHARetryClient;
+import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.network.TransportContext;
 import org.apache.celeborn.common.network.buffer.NettyManagedBuffer;
 import org.apache.celeborn.common.network.client.RpcResponseCallback;

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -30,13 +30,13 @@ import org.roaringbitmap.RoaringBitmap
 
 import org.apache.celeborn.common.RssConf
 import org.apache.celeborn.common.haclient.RssHARetryClient
-import org.apache.celeborn.common.identity.IdentityProvider
+import org.apache.celeborn.common.identity.{IdentityProvider, UserIdentifier}
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{PartitionLocationInfo, WorkerInfo}
 import org.apache.celeborn.common.protocol._
 import org.apache.celeborn.common.protocol.RpcNameConstants.WORKER_EP
-import org.apache.celeborn.common.protocol.message.{ControlMessages, StatusCode}
 import org.apache.celeborn.common.protocol.message.ControlMessages._
+import org.apache.celeborn.common.protocol.message.StatusCode
 import org.apache.celeborn.common.rpc._
 import org.apache.celeborn.common.util.{ThreadUtils, Utils}
 

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientSuiteJ.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 import org.apache.celeborn.client.compress.Compressor;
 import org.apache.celeborn.client.compress.Compressor.CompressionCodec;
 import org.apache.celeborn.common.RssConf;
+import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.network.client.TransportClient;
 import org.apache.celeborn.common.network.client.TransportClientFactory;
 import org.apache.celeborn.common.protocol.PartitionLocation;

--- a/common/src/main/java/org/apache/celeborn/common/meta/FileInfo.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/FileInfo.java
@@ -27,7 +27,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
-import org.apache.celeborn.common.protocol.message.ControlMessages.UserIdentifier;
+import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.util.Utils;
 
 public class FileInfo {

--- a/common/src/main/java/org/apache/celeborn/common/util/PbSerDeUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/PbSerDeUtils.java
@@ -22,6 +22,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 
+import org.apache.celeborn.common.identity.UserIdentifier;
+import org.apache.celeborn.common.identity.UserIdentifier$;
 import org.apache.celeborn.common.meta.DiskInfo;
 import org.apache.celeborn.common.meta.FileInfo;
 import org.apache.celeborn.common.meta.WorkerInfo;

--- a/common/src/main/scala/org/apache/celeborn/common/identity/DefaultIdentityProvider.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/identity/DefaultIdentityProvider.scala
@@ -19,11 +19,8 @@ package org.apache.celeborn.common.identity
 
 import org.apache.hadoop.security.UserGroupInformation
 
-import org.apache.celeborn.common.protocol.message.ControlMessages
-import org.apache.celeborn.common.protocol.message.ControlMessages.UserIdentifier
-
 class DefaultIdentityProvider extends IdentityProvider {
-  override def provide(): ControlMessages.UserIdentifier = {
+  override def provide(): UserIdentifier = {
     UserIdentifier(
       IdentityProvider.DEFAULT_TENANT_ID,
       UserGroupInformation.getCurrentUser.getShortUserName)

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -23,12 +23,11 @@ import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.JavaConverters._
 
+import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.internal.Logging
-import org.apache.celeborn.common.protocol.PbWorkerInfo
-import org.apache.celeborn.common.protocol.message.ControlMessages.{ResourceConsumption, UserIdentifier}
+import org.apache.celeborn.common.protocol.message.ControlMessages.ResourceConsumption
 import org.apache.celeborn.common.rpc.RpcEndpointRef
 import org.apache.celeborn.common.rpc.netty.NettyRpcEndpointRef
-import org.apache.celeborn.common.util.PbSerDeUtils
 
 class WorkerInfo(
     val host: String,

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -24,7 +24,7 @@ import scala.collection.JavaConverters._
 
 import org.roaringbitmap.RoaringBitmap
 
-import org.apache.celeborn.common.exception.RssException
+import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{DiskInfo, WorkerInfo}
 import org.apache.celeborn.common.network.protocol.TransportMessage
@@ -392,31 +392,6 @@ object ControlMessages extends Logging {
   case object ThreadDump extends Message
 
   case class ThreadDumpResponse(threadDump: String) extends Message
-
-  case class UserIdentifier(tenantId: String, name: String) extends Message {
-    assert(
-      tenantId != null && tenantId.nonEmpty,
-      "UserIdentifier's tenantId should not be null or empty.")
-    assert(name != null && name.nonEmpty, "UserIdentifier's name should not be null or empty.")
-
-    override def toString: String = {
-      s"`$tenantId`.`$name`"
-    }
-  }
-
-  object UserIdentifier {
-    val USER_IDENTIFIER = "^\\`(.+)\\`\\.\\`(.+)\\`$".r
-
-    def apply(userIdentifier: String): UserIdentifier = {
-      if (USER_IDENTIFIER.findPrefixOf(userIdentifier).isDefined) {
-        val USER_IDENTIFIER(tenantId, name) = userIdentifier
-        UserIdentifier(tenantId, name)
-      } else {
-        logError(s"Failed to parse user identifier: $userIdentifier")
-        throw new RssException(s"Failed to parse user identifier: ${userIdentifier}")
-      }
-    }
-  }
 
   case class ResourceConsumption(
       diskBytesWritten: Long,

--- a/common/src/main/scala/org/apache/celeborn/common/quota/DefaultQuotaManager.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/quota/DefaultQuotaManager.scala
@@ -24,7 +24,7 @@ import scala.collection.JavaConverters._
 import org.yaml.snakeyaml.Yaml
 
 import org.apache.celeborn.common.RssConf
-import org.apache.celeborn.common.protocol.message.ControlMessages.UserIdentifier
+import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.util.Utils
 
 class DefaultQuotaManager(conf: RssConf) extends QuotaManager(conf) {

--- a/common/src/main/scala/org/apache/celeborn/common/quota/Quota.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/quota/Quota.scala
@@ -17,8 +17,9 @@
 
 package org.apache.celeborn.common.quota
 
+import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.internal.Logging
-import org.apache.celeborn.common.protocol.message.ControlMessages.{ResourceConsumption, UserIdentifier}
+import org.apache.celeborn.common.protocol.message.ControlMessages.ResourceConsumption
 import org.apache.celeborn.common.util.Utils
 
 case class Quota(

--- a/common/src/main/scala/org/apache/celeborn/common/quota/QuotaManager.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/quota/QuotaManager.scala
@@ -19,8 +19,8 @@ package org.apache.celeborn.common.quota
 import java.util.concurrent.ConcurrentHashMap
 
 import org.apache.celeborn.common.RssConf
+import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.internal.Logging
-import org.apache.celeborn.common.protocol.message.ControlMessages.UserIdentifier
 
 abstract class QuotaManager(conf: RssConf) extends Logging {
 

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -48,7 +48,7 @@ import org.apache.celeborn.common.network.util.{ConfigProvider, JavaUtils, Trans
 import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionSplitMode, PartitionType}
 import org.apache.celeborn.common.protocol.PbWorkerResource
 import org.apache.celeborn.common.protocol.message.{ControlMessages, Message, StatusCode}
-import org.apache.celeborn.common.protocol.message.ControlMessages.{UserIdentifier, WorkerResource}
+import org.apache.celeborn.common.protocol.message.ControlMessages.WorkerResource
 
 object Utils extends Logging {
 

--- a/common/src/test/scala/org/apache/celeborn/common/identity/UserIdentifierSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/identity/UserIdentifierSuite.scala
@@ -19,7 +19,6 @@ package org.apache.celeborn.common.identity
 
 import org.apache.celeborn.RssFunSuite
 import org.apache.celeborn.common.exception.RssException
-import org.apache.celeborn.common.protocol.message.ControlMessages.UserIdentifier
 
 class UserIdentifierSuite extends RssFunSuite {
 

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
@@ -30,7 +30,8 @@ import org.junit.Assert.{assertEquals, assertNotEquals, assertNotNull}
 
 import org.apache.celeborn.RssFunSuite
 import org.apache.celeborn.common.RssConf
-import org.apache.celeborn.common.protocol.message.ControlMessages.{ResourceConsumption, UserIdentifier}
+import org.apache.celeborn.common.identity.UserIdentifier
+import org.apache.celeborn.common.protocol.message.ControlMessages.ResourceConsumption
 import org.apache.celeborn.common.rpc.{RpcAddress, RpcEndpointAddress, RpcEndpointRef, RpcEnv, RpcTimeout}
 import org.apache.celeborn.common.rpc.netty.{NettyRpcEndpointRef, NettyRpcEnv}
 import org.apache.celeborn.common.util.ThreadUtils

--- a/common/src/test/scala/org/apache/celeborn/common/quota/DefaultQuotaManagerSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/quota/DefaultQuotaManagerSuite.scala
@@ -20,7 +20,7 @@ package org.apache.celeborn.common.quota
 import org.junit.Assert.assertEquals
 
 import org.apache.celeborn.common.RssConf
-import org.apache.celeborn.common.protocol.message.ControlMessages.UserIdentifier
+import org.apache.celeborn.common.identity.UserIdentifier
 
 class DefaultQuotaManagerSuite extends BaseQuotaManagerSuite {
 

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -33,10 +33,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.RssConf;
+import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.meta.DiskInfo;
 import org.apache.celeborn.common.meta.WorkerInfo;
 import org.apache.celeborn.common.protocol.message.ControlMessages.ResourceConsumption;
-import org.apache.celeborn.common.protocol.message.ControlMessages.UserIdentifier;
 import org.apache.celeborn.common.rpc.RpcAddress;
 import org.apache.celeborn.common.rpc.RpcEnv;
 import org.apache.celeborn.common.util.Utils;

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/IMetadataHandler.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/IMetadataHandler.java
@@ -20,10 +20,10 @@ package org.apache.celeborn.service.deploy.master.clustermeta;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.meta.DiskInfo;
 import org.apache.celeborn.common.meta.WorkerInfo;
 import org.apache.celeborn.common.protocol.message.ControlMessages.ResourceConsumption;
-import org.apache.celeborn.common.protocol.message.ControlMessages.UserIdentifier;
 
 public interface IMetadataHandler {
   void handleRequestSlots(

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/MetaUtil.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/MetaUtil.java
@@ -20,11 +20,11 @@ package org.apache.celeborn.service.deploy.master.clustermeta;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.celeborn.common.identity.UserIdentifier;
+import org.apache.celeborn.common.identity.UserIdentifier$;
 import org.apache.celeborn.common.meta.DiskInfo;
 import org.apache.celeborn.common.meta.WorkerInfo;
-import org.apache.celeborn.common.protocol.message.ControlMessages;
 import org.apache.celeborn.common.protocol.message.ControlMessages.ResourceConsumption;
-import org.apache.celeborn.common.protocol.message.ControlMessages.UserIdentifier;
 import org.apache.celeborn.common.util.Utils;
 
 public class MetaUtil {
@@ -92,7 +92,7 @@ public class MetaUtil {
                   v.getDiskFileCount(),
                   v.getHdfsBytesWritten(),
                   v.getHdfsFileCount());
-          map.put(ControlMessages.UserIdentifier$.MODULE$.apply(k), resourceConsumption);
+          map.put(UserIdentifier$.MODULE$.apply(k), resourceConsumption);
         });
     return map;
   }

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/SingleMasterMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/SingleMasterMetaManager.java
@@ -24,10 +24,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.RssConf;
+import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.meta.DiskInfo;
 import org.apache.celeborn.common.meta.WorkerInfo;
 import org.apache.celeborn.common.protocol.message.ControlMessages.ResourceConsumption;
-import org.apache.celeborn.common.protocol.message.ControlMessages.UserIdentifier;
 import org.apache.celeborn.common.rpc.RpcEnv;
 
 public class SingleMasterMetaManager extends AbstractMetaManager {

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HAMasterMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HAMasterMetaManager.java
@@ -27,10 +27,10 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.RssConf;
 import org.apache.celeborn.common.haclient.RssHARetryClient;
+import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.meta.DiskInfo;
 import org.apache.celeborn.common.meta.WorkerInfo;
 import org.apache.celeborn.common.protocol.message.ControlMessages.ResourceConsumption;
-import org.apache.celeborn.common.protocol.message.ControlMessages.UserIdentifier;
 import org.apache.celeborn.common.rpc.RpcEnv;
 import org.apache.celeborn.service.deploy.master.clustermeta.AbstractMetaManager;
 import org.apache.celeborn.service.deploy.master.clustermeta.MetaUtil;

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MetaHandler.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MetaHandler.java
@@ -29,10 +29,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.RssConf;
+import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.meta.DiskInfo;
 import org.apache.celeborn.common.meta.WorkerInfo;
 import org.apache.celeborn.common.protocol.message.ControlMessages.ResourceConsumption;
-import org.apache.celeborn.common.protocol.message.ControlMessages.UserIdentifier;
 import org.apache.celeborn.service.deploy.master.clustermeta.MetaUtil;
 import org.apache.celeborn.service.deploy.master.clustermeta.ResourceProtos;
 import org.apache.celeborn.service.deploy.master.clustermeta.ResourceProtos.ResourceResponse;

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -28,6 +28,7 @@ import scala.util.Random
 import org.apache.celeborn.common.RssConf
 import org.apache.celeborn.common.RssConf.haEnabled
 import org.apache.celeborn.common.haclient.RssHARetryClient
+import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{DiskInfo, WorkerInfo}
 import org.apache.celeborn.common.metrics.MetricsSystem

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
@@ -35,10 +35,10 @@ import org.junit.Test;
 
 import org.apache.celeborn.common.RssConf;
 import org.apache.celeborn.common.haclient.RssHARetryClient;
+import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.meta.DiskInfo;
 import org.apache.celeborn.common.meta.WorkerInfo;
 import org.apache.celeborn.common.protocol.message.ControlMessages.ResourceConsumption;
-import org.apache.celeborn.common.protocol.message.ControlMessages.UserIdentifier;
 import org.apache.celeborn.common.rpc.RpcEndpointAddress;
 import org.apache.celeborn.common.rpc.RpcEndpointRef;
 import org.apache.celeborn.common.rpc.RpcEnv;

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
@@ -37,10 +37,10 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import org.apache.celeborn.common.RssConf;
+import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.meta.DiskInfo;
 import org.apache.celeborn.common.meta.WorkerInfo;
 import org.apache.celeborn.common.protocol.message.ControlMessages.ResourceConsumption;
-import org.apache.celeborn.common.protocol.message.ControlMessages.UserIdentifier;
 import org.apache.celeborn.common.util.Utils;
 import org.apache.celeborn.service.deploy.master.clustermeta.ResourceProtos;
 import org.apache.celeborn.service.deploy.master.clustermeta.ResourceProtos.RequestSlotsRequest;

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -33,10 +33,10 @@ import org.mockito.Mockito;
 
 import org.apache.celeborn.common.RssConf;
 import org.apache.celeborn.common.haclient.RssHARetryClient;
+import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.meta.DiskInfo;
 import org.apache.celeborn.common.meta.WorkerInfo;
 import org.apache.celeborn.common.protocol.message.ControlMessages.ResourceConsumption;
-import org.apache.celeborn.common.protocol.message.ControlMessages.UserIdentifier;
 import org.apache.celeborn.common.rpc.RpcEndpointAddress;
 import org.apache.celeborn.common.rpc.RpcEndpointRef;
 import org.apache.celeborn.common.rpc.RpcEnv;

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -50,10 +50,10 @@ import org.slf4j.LoggerFactory;
 import sun.nio.ch.DirectBuffer;
 
 import org.apache.celeborn.common.RssConf;
+import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.meta.FileInfo;
 import org.apache.celeborn.common.metrics.source.AbstractSource;
 import org.apache.celeborn.common.network.server.MemoryTracker;
-import org.apache.celeborn.common.protocol.message.ControlMessages.UserIdentifier;
 import org.apache.celeborn.common.unsafe.Platform;
 import org.apache.celeborn.common.util.PbSerDeUtils;
 import org.apache.celeborn.common.util.ShuffleBlockInfoUtils;

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -29,6 +29,7 @@ import io.netty.util.{HashedWheelTimer, Timeout, TimerTask}
 import org.roaringbitmap.RoaringBitmap
 
 import org.apache.celeborn.common.RssConf
+import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{PartitionLocationInfo, WorkerInfo}
 import org.apache.celeborn.common.metrics.MetricsSystem

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -36,12 +36,13 @@ import org.iq80.leveldb.DB
 
 import org.apache.celeborn.common.RssConf
 import org.apache.celeborn.common.exception.RssException
+import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{DeviceInfo, DiskInfo, DiskStatus, FileInfo}
 import org.apache.celeborn.common.metrics.source.AbstractSource
 import org.apache.celeborn.common.network.server.MemoryTracker.MemoryTrackerListener
 import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionSplitMode, PartitionType}
-import org.apache.celeborn.common.protocol.message.ControlMessages.{ResourceConsumption, UserIdentifier}
+import org.apache.celeborn.common.protocol.message.ControlMessages.ResourceConsumption
 import org.apache.celeborn.common.util.{PbSerDeUtils, ThreadUtils, Utils}
 import org.apache.celeborn.service.deploy.worker._
 import org.apache.celeborn.service.deploy.worker.storage.StorageManager.hdfsFs

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
@@ -55,6 +55,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.RssConf;
+import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.meta.FileInfo;
 import org.apache.celeborn.common.metrics.MetricsSystem;
 import org.apache.celeborn.common.metrics.source.RPCSource;
@@ -74,7 +75,6 @@ import org.apache.celeborn.common.network.util.TransportConf;
 import org.apache.celeborn.common.protocol.PartitionSplitMode;
 import org.apache.celeborn.common.protocol.PartitionType;
 import org.apache.celeborn.common.protocol.StorageInfo;
-import org.apache.celeborn.common.protocol.message.ControlMessages.UserIdentifier;
 import org.apache.celeborn.common.util.ThreadUtils;
 import org.apache.celeborn.common.util.Utils;
 import org.apache.celeborn.service.deploy.worker.FetchHandler;

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorterSuiteJ.java
@@ -36,9 +36,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.RssConf;
+import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.meta.FileInfo;
 import org.apache.celeborn.common.network.server.MemoryTracker;
-import org.apache.celeborn.common.protocol.message.ControlMessages.UserIdentifier;
 import org.apache.celeborn.common.unsafe.Platform;
 import org.apache.celeborn.common.util.Utils;
 import org.apache.celeborn.service.deploy.worker.WorkerSource;

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ClusterReadWriteSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ClusterReadWriteSuite.scala
@@ -27,7 +27,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.apache.celeborn.client.{LifecycleManager, ShuffleClientImpl}
 import org.apache.celeborn.client.compress.Compressor.CompressionCodec
 import org.apache.celeborn.common.RssConf
-import org.apache.celeborn.common.protocol.message.ControlMessages.UserIdentifier
+import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.service.deploy.MiniClusterFeature
 
 class ClusterReadWriteSuite extends AnyFunSuite with MiniClusterFeature with BeforeAndAfterAll {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove UserIdentifier from ControlMessage, and put it under `org.apache.celeborn.common.identity`

### Why are the changes needed?
Because this class doesn't belong to ControlMessage, it is a normal class bean, should be put with `IdentityProvider` and `DefaultIdentityProvider` together under `org.apache.celeborn.common.identity`.

### What are the items that need reviewer attention?


### Related issues.
#805 

### Related pull requests.


### How was this patch tested?


/cc @AngersZhuuuu 

/assign @main-reviewer
