### PR TITLE
[BUG] RegisterShuffle should not increase epoch

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -472,18 +472,20 @@ public class ShuffleClientImpl extends ShuffleClient {
     }
 
     // get location
-    if (!map.containsKey(partitionId)
-        && !revive(
-            applicationId,
-            shuffleId,
-            mapId,
-            attemptId,
-            partitionId,
-            -1,
-            null,
-            StatusCode.PUSH_DATA_FAIL_NON_CRITICAL_CAUSE)) {
-      throw new IOException(
-          "Revive for shuffle " + shuffleKey + " partitionId " + partitionId + " failed.");
+    if (!map.containsKey(partitionId)) {
+      logger.warn("It should never reach here!");
+      if (!revive(
+          applicationId,
+          shuffleId,
+          mapId,
+          attemptId,
+          partitionId,
+          -1,
+          null,
+          StatusCode.PUSH_DATA_FAIL_NON_CRITICAL_CAUSE)) {
+        throw new IOException(
+            "Revive for shuffle " + shuffleKey + " partitionId " + partitionId + " failed.");
+      }
     }
 
     if (mapperEnded(shuffleId, mapId, attemptId)) {

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -479,7 +479,7 @@ public class ShuffleClientImpl extends ShuffleClient {
             mapId,
             attemptId,
             partitionId,
-            0,
+            -1,
             null,
             StatusCode.PUSH_DATA_FAIL_NON_CRITICAL_CAUSE)) {
       throw new IOException(

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -449,7 +449,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
     // Third, for each slot, LifecycleManager should ask Worker to reserve the slot
     // and prepare the pushing data env.
     val reserveSlotsSuccess =
-      reserveSlotsWithRetry(applicationId, shuffleId, candidatesWorkers.asScala.toList, slots)
+      reserveSlotsWithRetry(applicationId, shuffleId, candidatesWorkers.asScala.toList, slots, false)
 
     // If reserve slots failed, clear allocated resources, reply ReserveSlotFailed and return.
     if (!reserveSlotsSuccess) {
@@ -1209,7 +1209,8 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       applicationId: String,
       shuffleId: Int,
       candidates: List[WorkerInfo],
-      slots: WorkerResource): Boolean = {
+      slots: WorkerResource,
+      updateEpoch: Boolean = true): Boolean = {
     var requestSlots = slots
     val reserveSlotsMaxRetries = conf.reserveSlotsMaxRetries
     val reserveSlotsRetryWait = conf.reserveSlotsRetryWait
@@ -1251,7 +1252,8 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
             // duplicated with existing partition locations.
             requestSlots = reallocateSlotsFromCandidates(
               failedPartitionLocations.values.toList,
-              retryCandidates.asScala.toList)
+              retryCandidates.asScala.toList,
+              updateEpoch)
             requestSlots.asScala.foreach { case (workerInfo, (retryMasterLocs, retrySlaveLocs)) =>
               val (masterPartitionLocations, slavePartitionLocations) =
                 slots.computeIfAbsent(workerInfo, newLocationFunc)
@@ -1296,11 +1298,12 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       id: Int,
       oldEpochId: Int,
       candidates: List[WorkerInfo],
-      slots: WorkerResource): Unit = {
+      slots: WorkerResource,
+      updateEpoch: Boolean = true): Unit = {
     val masterIndex = Random.nextInt(candidates.size)
     val masterLocation = new PartitionLocation(
       id,
-      oldEpochId + 1,
+      if (updateEpoch) oldEpochId + 1 else oldEpochId,
       candidates(masterIndex).host,
       candidates(masterIndex).rpcPort,
       candidates(masterIndex).pushPort,
@@ -1312,7 +1315,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       val slaveIndex = (masterIndex + 1) % candidates.size
       val slaveLocation = new PartitionLocation(
         id,
-        oldEpochId + 1,
+        if (updateEpoch) oldEpochId + 1 else oldEpochId,
         candidates(slaveIndex).host,
         candidates(slaveIndex).rpcPort,
         candidates(slaveIndex).pushPort,
@@ -1341,10 +1344,11 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
 
   private def reallocateSlotsFromCandidates(
       oldPartitions: List[PartitionLocation],
-      candidates: List[WorkerInfo]): WorkerResource = {
+      candidates: List[WorkerInfo],
+      updateEpoch: Boolean = true): WorkerResource = {
     val slots = new WorkerResource()
     oldPartitions.foreach { partition =>
-      allocateFromCandidates(partition.getId, partition.getEpoch, candidates, slots)
+      allocateFromCandidates(partition.getId, partition.getEpoch, candidates, slots, updateEpoch)
     }
     slots
   }

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -449,7 +449,12 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
     // Third, for each slot, LifecycleManager should ask Worker to reserve the slot
     // and prepare the pushing data env.
     val reserveSlotsSuccess =
-      reserveSlotsWithRetry(applicationId, shuffleId, candidatesWorkers.asScala.toList, slots, false)
+      reserveSlotsWithRetry(
+        applicationId,
+        shuffleId,
+        candidatesWorkers.asScala.toList,
+        slots,
+        false)
 
     // If reserve slots failed, clear allocated resources, reply ReserveSlotFailed and return.
     if (!reserveSlotsSuccess) {


### PR DESCRIPTION
# [BUG]/[FEATURE] title

### What changes were proposed in this pull request?
Currently ReserveSlotsWithRetry will increase epoch, which means after RegisterShuffle the epoch may not all be zero. As a result, the follow-up registerShuffle might not return all registered PartitionLocations because it filters out partitions whose epoch not equal to zero.
```
          val initialLocs = workerSnapshots(shuffleId)
            .values()
            .asScala
            .flatMap(_.getAllMasterLocationsWithMinEpoch(shuffleId.toString).asScala)
            .filter(_.getEpoch == 0)
            .toArray
```
Then shuffle client will trigger revive
```
    if (!map.containsKey(partitionId)
        && !revive(
            applicationId,
            shuffleId,
            mapId,
            attemptId,
            partitionId,
            0,
            null,
            StatusCode.PUSH_DATA_FAIL_NON_CRITICAL_CAUSE))
```
And eventually leads to lots of revive request in LifeCycleManager
```
22/10/22 20:22:46 WARN LifecycleManager: Do Revive for shuffle application_1664260775537_5378832_1-34, oldPartition: null, cause: StatusCode{value=PushDataFailNonCriticalCause}
22/10/22 20:22:46 WARN LifecycleManager: Do Revive for shuffle application_1664260775537_5378832_1-34, oldPartition: null, cause: StatusCode{value=PushDataFailNonCriticalCause}
22/10/22 20:22:46 WARN LifecycleManager: Do Revive for shuffle application_1664260775537_5378832_1-34, oldPartition: null, cause: StatusCode{value=PushDataFailNonCriticalCause}
22/10/22 20:22:46 WARN LifecycleManager: Do Revive for shuffle application_1664260775537_5378832_1-34, oldPartition: null, cause: StatusCode{value=PushDataFailNonCriticalCause}
22/10/22 20:22:46 WARN LifecycleManager: Do Revive for shuffle application_1664260775537_5378832_1-34, oldPartition: null, cause: StatusCode{value=PushDataFailNonCriticalCause}
22/10/22 20:22:46 WARN LifecycleManager: Do Revive for shuffle application_1664260775537_5378832_1-34, oldPartition: null, cause: StatusCode{value=PushDataFailNonCriticalCause}
22/10/22 20:22:46 WARN LifecycleManager: Do Revive for shuffle application_1664260775537_5378832_1-34, oldPartition: null, cause: StatusCode{value=PushDataFailNonCriticalCause}
22/10/22 20:22:46 WARN LifecycleManager: Do Revive for shuffle application_1664260775537_5378832_1-34, oldPartition: null, cause: StatusCode{value=PushDataFailNonCriticalCause}
22/10/22 20:22:46 WARN LifecycleManager: Do Revive for shuffle application_1664260775537_5378832_1-34, oldPartition: null, cause: StatusCode{value=PushDataFailNonCriticalCause}
22/10/22 20:22:46 WARN LifecycleManager: Do Revive for shuffle application_1664260775537_5378832_1-34, oldPartition: null, cause: StatusCode{value=PushDataFailNonCriticalCause}
22/10/22 20:22:46 WARN LifecycleManager: Do Revive for shuffle application_1664260775537_5378832_1-34, oldPartition: null, cause: StatusCode{value=PushDataFailNonCriticalCause}
22/10/22 20:22:46 WARN LifecycleManager: Do Revive for shuffle application_1664260775537_5378832_1-34, oldPartition: null, cause: StatusCode{value=PushDataFailNonCriticalCause}
22/10/22 20:22:46 WARN LifecycleManager: Do Revive for shuffle application_1664260775537_5378832_1-34, oldPartition: null, cause: StatusCode{value=PushDataFailNonCriticalCause}
22/10/22 20:22:46 WARN LifecycleManager: Do Revive for shuffle application_1664260775537_5378832_1-34, oldPartition: null, cause: StatusCode{value=PushDataFailNonCriticalCause}
22/10/22 20:22:46 WARN LifecycleManager: Do Revive for shuffle application_1664260775537_5378832_1-34, oldPartition: null, cause: StatusCode{value=PushDataFailNonCriticalCause}
```

This is not really bug since it will not cause Exception or incorrectness, it only causes too many revive requests in some cases and print lots of log.

### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
