### PR TITLE
[ISSUE-863][BUG]LifecycleManager should ignore change partition request when shuffle ended and not remove workersnapshot when commit success

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -592,7 +592,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       return
     }
 
-    if(stageEndShuffleSet.contains(shuffleId)) {
+    if (stageEndShuffleSet.contains(shuffleId)) {
       logError(s"[handleChangePartition] shuffle $shuffleId already ended!")
       context.reply(ChangeLocationResponse(StatusCode.STAGE_ENDED, None))
       return


### PR DESCRIPTION
### What changes were proposed in this pull request?

33-478-1 create file twice

Worker
```
22/10/25 15:09:21,828 DEBUG [dispatcher-event-loop-14] Worker: Received ReserveSlots request, application_1665646136650_2510409_1-33, master partitions: 478-1; slave partitions: .
22/10/25 15:09:21,828 INFO [dispatcher-event-loop-14] Worker: Reserved 1 master location and 0 slave location for application_1665646136650_2510409_1-33 master: [PartitionLocation[478-1 10.130.86.41:9092:9094:9093:9095 Mode: Master peer: 10.130.75.25:9092:9094:9093storage hint:MEMORY]]
22/10/25 15:25:27,728 DEBUG [dispatcher-event-loop-43] Worker: Received CommitFiles request, application_1665646136650_2510409_1-33, master files 64-1,833-0,1345-1,164-1,584-2,1161-1,1129-2,1131-0,237-0,818-1,819-1,1429-0,535-0,733-1,478-1; slave files 832-0,672-1,130-1,134-1,1130-0,1034-1,236-0,268-1,883-1,1428-0,564-1,534-0,508-1,221-1.
22/10/25 15:25:31,807 DEBUG [dispatcher-event-loop-32] Worker: Received ReserveSlots request, application_1665646136650_2510409_1-33, master partitions: 478-1; slave partitions: .
22/10/25 15:25:32,130 INFO [dispatcher-event-loop-32] Worker: Reserved 1 master location and 0 slave location for application_1665646136650_2510409_1-33 master: [PartitionLocation[478-1 10.130.86.41:9092:9094:9093:9095 Mode: Master peer: 10.130.75.25:9092:9094:9093storage hint:MEMORY]]

```
LifecycleManager
```
22/10/25 15:09:21 WARN LifecycleManager: Batch handle change partition for application_1665646136650_2510409_1 of [33-478-0]
22/10/25 15:09:21 INFO LifecycleManager: Reserve buffer success for application_1665646136650_2510409_1-33
22/10/25 15:09:21 WARN LifecycleManager: Renew 33 [(478 0 -> 1)]  success.
22/10/25 15:25:31 INFO LifecycleManager: Succeed to handle stageEnd for 33.
22/10/25 15:25:31 WARN LifecycleManager: New partition not found, old partition 33 478-0
22/10/25 15:25:31 WARN LifecycleManager: Batch handle change partition for application_1665646136650_2510409_1 of [33-478-0]
22/10/25 15:25:31 WARN LifecycleManager: Renew 33 []  success. 
```

### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.
close #863

### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
