### PR TITLE
[ISSUE-867][BUG] Create writer failed should report non-critical error instead of critical error

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
@@ -441,4 +441,7 @@ public final class FileWriter implements DeviceObserver {
 
   @Override
   public void notifyHighDiskUsage(String mountPoint) {}
+
+  @Override
+  public void notifyNonCriticalError(String mountPoint, DiskStatus diskStatus) {}
 }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitor.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitor.scala
@@ -99,7 +99,7 @@ class LocalDeviceMonitor(
       this.synchronized {
         diskInfos.get(mountPoint).setStatus(diskStatus)
         val tmpObservers = new util.HashSet[DeviceObserver](observers)
-        tmpObservers.asScala.foreach(ob => ob.notifyNonCriticalError(mountPoint, diskStatus))
+        tmpObservers.asScala.foreach(_.notifyNonCriticalError(mountPoint, diskStatus))
       }
 
     def notifyObserversOnHealthy(mountPoint: String): Unit = this.synchronized {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceObserver.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceObserver.scala
@@ -21,6 +21,7 @@ import org.apache.celeborn.common.meta.DiskStatus
 
 trait DeviceObserver {
   def notifyError(mountPoint: String, diskStatus: DiskStatus): Unit = {}
+  def notifyNonCriticalError(mountPoint: String, diskStatus: DiskStatus): Unit = {}
   def notifyHealthy(mountPoint: String): Unit = {}
   def notifyHighDiskUsage(mountPoint: String): Unit = {}
 }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/Flusher.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/Flusher.scala
@@ -190,7 +190,7 @@ private[worker] class LocalFlusher(
 
   override def processIOException(e: IOException, deviceErrorType: DiskStatus): Unit = {
     stopFlag.set(true)
-    logError(s"$this write failed, report to DeviceMonitor, eception: $e")
+    logError(s"$this write failed, report to DeviceMonitor, exception: $e")
     deviceMonitor.reportDeviceError(mountPoint, e, deviceErrorType)
   }
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -348,6 +348,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
         } catch {
           case fe: FileAlreadyExistsException =>
             logError("Failed to create fileWriter because of existed file", fe)
+            throw fe
           case t: Throwable =>
             logError(
               s"Create FileWriter for ${file.getAbsolutePath} of mount $mountPoint " +

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -337,7 +337,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
           case fe: FileAlreadyExistsException =>
             logError(s"Target file ${file.getAbsolutePath} of fileWriter already exists.")
             exception = new IOException(fe)
-            deviceMonitor.report
+            deviceMonitor.reportNonCriticalError(mountPoint, fe)
           case rsse: RssException =>
             logError(
               s"Create FileWriter for ${file.getAbsolutePath} of mount $mountPoint failed, report to DeviceMonitor",

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -154,17 +154,6 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
     }
   }
 
-  override def notifyNonCriticalError(mountPoint: String, diskStatus: DiskStatus): Unit =
-    this.synchronized {
-      if (diskStatus == DiskStatus.READ_OR_WRITE_FAILURE) {
-        logInfo("Face read or writer failure, remove disk operator.")
-        val operator = diskOperators.remove(mountPoint)
-        if (operator != null) {
-          operator.shutdown()
-        }
-      }
-    }
-
   private val counter = new AtomicInteger()
   private val counterOperator = new IntUnaryOperator() {
     override def applyAsInt(operand: Int): Int = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Create writer failed should report non-critical error instead of critical error

### Why are the changes needed?
To avoid the problem that execute createWriter() method twice will make all Flusher‘s thread stop and hang on the normal execution of worker.

### What are the items that need reviewer attention?
Could we just ignore the request if we check that the target file of fileWriter already exists. And if there is other I/O issue when creating filewriter, we could handle it by previous way.

### Related issues.
close #867 

### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
