### PR TITLE
[ISSUE-882][REFACTOR][K8S] Refactor dockerfile to build docker image from binary instead of ADD tgz

### DIFF
--- a/docker/DEPLOY_ON_K8S.md
+++ b/docker/DEPLOY_ON_K8S.md
@@ -4,15 +4,13 @@
 Celeborn is recommended to be deployed on nodes with local disk. Before starting, please make sure local disks on nodes are mounted to specific path.
 
 ## [Optional] Build Celeborn docker image
-We have provided a docker image for Celeborn in helm chart. If you want to build your own Celeborn image with specific version, run docker build with our Dockerfile.
+We have provided a docker image for Celeborn in helm chart. If you want to build your own Celeborn image, run docker build with our Dockerfile.
+
+You should download or build your binary package first, then decompress it, cd decompress directory, use following command to build docker image.
 
 `
-docker build -f docker/Dockerfile --build-arg celeborn_version=0.1.0 -t ${your-repo}:${tag} .
+docker build -f docker/Dockerfile -t ${your-repo}:${tag} .
 `
-
-You can use `--build-arg celeborn_version` to indicates the version of Celeborn currently in use, default value is 0.1.1.
-
-Make sure you have already built Celeborn, the target file 'apache-celeborn-${project.version}-bin.tgz' is in ${CELEBORN_HOME}.
 
 ## Deploy Celeborn with helm
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,8 +18,6 @@
 ARG java_image_tag=8-jdk-focal
 FROM eclipse-temurin:${java_image_tag}
 
-ARG celeborn_version=0.1.1
-
 USER root
 
 RUN set -ex && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,8 +27,11 @@ RUN set -ex && \
     apt-get install -y bash tini busybox bind9-utils telnet net-tools procps krb5-user dnsutils && \
     ln -snf /bin/bash /bin/sh && \
     rm -rf /var/cache/apt/* && \
-    mkdir -p /opt/
+    mkdir -p /opt/celeborn
 
-ADD apache-celeborn-${celeborn_version}-bin.tgz /opt/
-
-RUN ln -s /opt/apache-celeborn-${celeborn_version}-bin /opt/celeborn
+COPY bin /opt/celeborn/bin
+COPY sbin /opt/celeborn/sbin
+COPY conf /opt/celeborn/conf
+COPY RELEASE /opt/celeborn/RELEASE
+COPY master-jars /opt/celeborn/master-jars
+COPY worker-jars /opt/celeborn/worker-jars


### PR DESCRIPTION
# [BUG]/[FEATURE] title

### What changes were proposed in this pull request?

User can custom build tgz with their prefer name, old dockerfile need fixed name tgz to build docker image.

Theoretically, users should build custom images from binary rather than adding tgz directly.

### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.
Close #882 


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
