### PR TITLE
Remove Netty from Spark Client Shaded Jar

### DIFF
--- a/client-spark/spark-2-shaded/pom.xml
+++ b/client-spark/spark-2-shaded/pom.xml
@@ -52,10 +52,6 @@
               <shadedPattern>org.apache.celeborn.com.google.common</shadedPattern>
             </relocation>
             <relocation>
-              <pattern>io.netty</pattern>
-              <shadedPattern>org.apache.celeborn.io.netty</shadedPattern>
-            </relocation>
-            <relocation>
               <pattern>org.apache.commons</pattern>
               <shadedPattern>org.apache.celeborn.org.apache.commons</shadedPattern>
             </relocation>
@@ -65,7 +61,6 @@
               <include>org.apache.celeborn:*</include>
               <include>com.google.protobuf:protobuf-java</include>
               <include>com.google.guava:guava</include>
-              <include>io.netty:*</include>
               <include>org.apache.commons:commons-lang3</include>
             </includes>
           </artifactSet>

--- a/client-spark/spark-3-shaded/pom.xml
+++ b/client-spark/spark-3-shaded/pom.xml
@@ -52,10 +52,6 @@
               <shadedPattern>org.apache.celeborn.com.google.common</shadedPattern>
             </relocation>
             <relocation>
-              <pattern>io.netty</pattern>
-              <shadedPattern>org.apache.celeborn.io.netty</shadedPattern>
-            </relocation>
-            <relocation>
               <pattern>org.apache.commons</pattern>
               <shadedPattern>org.apache.celeborn.org.apache.commons</shadedPattern>
             </relocation>
@@ -65,7 +61,6 @@
               <include>org.apache.celeborn:*</include>
               <include>com.google.protobuf:protobuf-java</include>
               <include>com.google.guava:guava</include>
-              <include>io.netty:*</include>
               <include>org.apache.commons:commons-lang3</include>
             </includes>
           </artifactSet>

--- a/common/src/main/java/org/apache/celeborn/common/network/util/NettyUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/util/NettyUtils.java
@@ -122,10 +122,9 @@ public class NettyUtils {
     //    enable `useCacheForAllThreads`.
     // This affects Spark 3.4 and above, see details in SPARK-38541.
 
-    // Use deprecated method to compatible w/ earlier Netty versions(less than 4.1.52.Final), which
-    // is used by Spark 3.1 and earlier versions. See details in
-    // https://github.com/netty/netty/pull/10267
-    // and SPARK-35132.
+    // Use deprecated method to compatible w/ earlier Netty versions(less than 4.1.52.Final),
+    // which is used by Spark 3.1 and earlier versions. See details in SPARK-35132 and
+    // https://github.com/netty/netty/pull/10267.
     return new PooledByteBufAllocator(
         allowDirectBufs && PlatformDependent.directBufferPreferred(),
         Math.min(PooledByteBufAllocator.defaultNumHeapArena(), numCores),

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,6 @@
     <log4j2.version>2.17.1</log4j2.version>
     <mockito.version>1.10.19</mockito.version>
     <mockito-scalatest.version>1.16.37</mockito-scalatest.version>
-    <netty.version>4.1.77.Final</netty.version>
     <protobuf.version>3.19.2</protobuf.version>
     <ratis.version>2.3.0</ratis.version>
     <scalamock.version>5.1.0</scalamock.version>
@@ -850,6 +849,7 @@
         <jackson.version>2.6.7</jackson.version>
         <jackson.databind.version>2.6.7.3</jackson.databind.version>
         <lz4-java.version>1.4.0</lz4-java.version>
+        <netty.version>4.1.47.Final</netty.version>
         <scala.version>2.11.12</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
         <spark.version>2.4.8</spark.version>
@@ -880,6 +880,7 @@
         <jackson.version>2.10.0</jackson.version>
         <jackson.databind.version>2.10.0</jackson.databind.version>
         <lz4-java.version>1.7.1</lz4-java.version>
+        <netty.version>4.1.47.Final</netty.version>
         <scala.version>2.12.10</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.0.3</spark.version>
@@ -898,6 +899,7 @@
         <jackson.version>2.10.0</jackson.version>
         <jackson.databind.version>2.10.0</jackson.databind.version>
         <lz4-java.version>1.7.1</lz4-java.version>
+        <netty.version>4.1.51.Final</netty.version>
         <scala.version>2.12.10</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.1.3</spark.version>
@@ -916,6 +918,7 @@
         <jackson.version>2.12.3</jackson.version>
         <jackson.databind.version>2.12.3</jackson.databind.version>
         <lz4-java.version>1.7.1</lz4-java.version>
+        <netty.version>4.1.68.Final</netty.version>
         <scala.version>2.12.15</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.2.2</spark.version>
@@ -934,6 +937,7 @@
         <jackson.version>2.13.3</jackson.version>
         <jackson.databind.version>2.13.3</jackson.databind.version>
         <lz4-java.version>1.8.0</lz4-java.version>
+        <netty.version>4.1.74.Final</netty.version>
         <scala.version>2.12.15</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.3.0</spark.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Align Netty version w/ Spark
- Remove Netty from Spark Client Shaded Jar

### Why are the changes needed?

Currently, Celeborn Spark Client Shaded Jar ships the relocated netty classes, but since there are native libs inside Netty, and it's not easy(IMO) to relocate native libs, then it still has conflict potentials.

<img width="516" alt="image" src="https://user-images.githubusercontent.com/26535726/198817557-fe829377-9cff-45a2-9c06-e26296537b9a.png">


### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
