### PR TITLE
[ISSUE-880][BUG] onTrim when flushFileWriters() should catch each file writer's exception, avoid block flush all file writers

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -546,7 +546,9 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
         writer.flushOnMemoryPressure()
       } catch {
         case t: Throwable =>
-          logError(s"FileWrite of ${writer} has face unexpected exception", t)
+          logError(
+            s"FileWrite of ${writer} faces unexpected exception when flush on memory pressure",
+            t)
       }
     }
   }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -542,7 +542,12 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
       }
     }
     allWriters.asScala.foreach { writer =>
-      writer.flushOnMemoryPressure()
+      try {
+        writer.flushOnMemoryPressure()
+      } catch {
+        case ioe: IOException =>
+          logError(s"FileWrite of ${writer} has face unexpected IOException", ioe)
+      }
     }
   }
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -539,7 +539,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
     workingDirWriters.asScala.foreach { case (_, writers) =>
       writers.synchronized {
         // Filter out FileWriter that already has IOException to avoid printing too many error logs
-        allWriters.addAll(writers.asScala.filter(_.getException != null).asJava)
+        allWriters.addAll(writers.asScala.filter(_.getException == null).asJava)
       }
     }
     allWriters.asScala.foreach { writer =>

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -545,8 +545,8 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
       try {
         writer.flushOnMemoryPressure()
       } catch {
-        case ioe: IOException =>
-          logError(s"FileWrite of ${writer} has face unexpected IOException", ioe)
+        case t: Throwable =>
+          logError(s"FileWrite of ${writer} has face unexpected exception", t)
       }
     }
   }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -538,6 +538,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
     val allWriters = new util.HashSet[FileWriter]()
     workingDirWriters.asScala.foreach { case (_, writers) =>
       writers.synchronized {
+        // Filter out FileWriter that already has IOException to avoid printing too many error logs
         allWriters.addAll(writers.asScala.filter(_.getException != null).asJava)
       }
     }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -538,7 +538,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
     val allWriters = new util.HashSet[FileWriter]()
     workingDirWriters.asScala.foreach { case (_, writers) =>
       writers.synchronized {
-        allWriters.addAll(writers)
+        allWriters.addAll(writers.asScala.filter(_.getException != null).asJava)
       }
     }
     allWriters.asScala.foreach { writer =>
@@ -547,7 +547,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
       } catch {
         case t: Throwable =>
           logError(
-            s"FileWrite of ${writer} faces unexpected exception when flush on memory pressure",
+            s"FileWrite of ${writer} faces unexpected exception when flush on memory pressure.",
             t)
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
onTrim when flushFileWriters() should catch each file writer's exception, avoid block flush all file writers

### Why are the changes needed?
To avoid some file writer's exception blocked all file writer's execution

### What are the items that need reviewer attention?


### Related issues.
#880 

### Related pull requests.


### How was this patch tested?


/cc @AngersZhuuuu 

/assign @main-reviewer
