### PR TITLE
[ISSUE-879][BUG] When notifyError, should destroy corresponding file writers

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
@@ -313,7 +313,7 @@ public final class FileWriter implements DeviceObserver {
       try {
         fileInfo.deleteAllFiles(StorageManager.hdfsFs());
       } catch (Exception e) {
-        logger.warn("clean hdfs file {}", fileInfo.getFilePath());
+        logger.warn("Exception when cleaning hdfs file {}", fileInfo.getFilePath());
       }
 
       // unregister from DeviceMonitor

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
@@ -433,17 +433,9 @@ public final class FileWriter implements DeviceObserver {
 
   @Override
   public void notifyError(String mountPoint, DiskStatus diskStatus) {
-    IOException ioe = new IOException("Device ERROR! Disk: " + mountPoint + " : " + diskStatus);
-    if (diskStatus == DiskStatus.READ_OR_WRITE_FAILURE) {
-      logger.error(
-          "Will destroy FileWriter {}, because disk {} status {}", this, mountPoint, diskStatus);
-      destroy(ioe);
-    } else {
-      if (!notifier.hasException()) {
-        notifier.setException(ioe);
-      }
-      deviceMonitor.unregisterFileWriter(this);
-    }
+    logger.error(
+        "Will destroy FileWriter {}, because disk {} status {}", this, mountPoint, diskStatus);
+    destroy(new IOException("Device ERROR! Disk: " + mountPoint + " : " + diskStatus));
   }
 
   // These empty methods are intended to match scala 2.11 restrictions that

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
@@ -433,9 +433,15 @@ public final class FileWriter implements DeviceObserver {
 
   @Override
   public void notifyError(String mountPoint, DiskStatus diskStatus) {
-    logger.error(
-        "Will destroy FileWriter {}, because disk {} status {}", this, mountPoint, diskStatus);
-    destroy(new IOException("Device ERROR! Disk: " + mountPoint + " : " + diskStatus));
+    destroy(
+        new IOException(
+            "Destroy FileWriter "
+                + this
+                + " by device ERROR."
+                + " Disk: "
+                + mountPoint
+                + " Status: "
+                + diskStatus));
   }
 
   // These empty methods are intended to match scala 2.11 restrictions that

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -177,7 +177,8 @@ private[deploy] class Controller(
       logWarning(s"[handleReserveSlots] $msg, will destroy writers.")
       masterLocs.asScala.foreach { partitionLocation =>
         val fileWriter = partitionLocation.asInstanceOf[WorkingPartition].getFileWriter
-        fileWriter.destroy(new IOException(s"Reserve slots failed for FileWriter ${fileWriter}"))
+        fileWriter.destroy(new IOException(s"Destroy FileWriter ${fileWriter} caused by " +
+          s"reserving slots failed for ${shuffleKey}."))
       }
       context.reply(ReserveSlotsResponse(StatusCode.RESERVE_SLOTS_FAILED, msg))
       return
@@ -215,11 +216,13 @@ private[deploy] class Controller(
       logWarning(s"[handleReserveSlots] $msg, destroy writers.")
       masterLocs.asScala.foreach { partitionLocation =>
         val fileWriter = partitionLocation.asInstanceOf[WorkingPartition].getFileWriter
-        fileWriter.destroy(new IOException(s"Reserve slots failed for FileWriter ${fileWriter}"))
+        fileWriter.destroy(new IOException(s"Destroy FileWriter ${fileWriter} caused by " +
+          s"reserving slots failed for ${shuffleKey}."))
       }
       slaveLocs.asScala.foreach { partitionLocation =>
         val fileWriter = partitionLocation.asInstanceOf[WorkingPartition].getFileWriter
-        fileWriter.destroy(new IOException(s"Reserve slots failed for FileWriter ${fileWriter}"))
+        fileWriter.destroy(new IOException(s"Destroy FileWriter ${fileWriter} caused by " +
+          s"reserving slots failed for ${shuffleKey}."))
       }
       context.reply(ReserveSlotsResponse(StatusCode.RESERVE_SLOTS_FAILED, msg))
       return
@@ -497,7 +500,7 @@ private[deploy] class Controller(
         } else {
           val fileWriter = allocatedLoc.asInstanceOf[WorkingPartition].getFileWriter
           fileWriter.destroy(
-            new IOException(s"Received destroy request for FileWriter ${fileWriter}"))
+            new IOException(s"Destroy FileWriter ${fileWriter} caused by receiving Destroy request."))
         }
       }
       // remove master locations from WorkerInfo
@@ -514,7 +517,7 @@ private[deploy] class Controller(
         } else {
           val fileWriter = allocatedLoc.asInstanceOf[WorkingPartition].getFileWriter
           fileWriter.destroy(
-            new IOException(s"Received destroy request for FileWriter ${fileWriter}"))
+            new IOException(s"Destroy FileWriter ${fileWriter} caused by receiving Destroy request."))
         }
       }
       // remove slave locations from worker info

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -500,7 +500,8 @@ private[deploy] class Controller(
         } else {
           val fileWriter = allocatedLoc.asInstanceOf[WorkingPartition].getFileWriter
           fileWriter.destroy(
-            new IOException(s"Destroy FileWriter ${fileWriter} caused by receiving Destroy request."))
+            new IOException(
+              s"Destroy FileWriter ${fileWriter} caused by receiving Destroy request."))
         }
       }
       // remove master locations from WorkerInfo
@@ -517,7 +518,8 @@ private[deploy] class Controller(
         } else {
           val fileWriter = allocatedLoc.asInstanceOf[WorkingPartition].getFileWriter
           fileWriter.destroy(
-            new IOException(s"Destroy FileWriter ${fileWriter} caused by receiving Destroy request."))
+            new IOException(
+              s"Destroy FileWriter ${fileWriter} caused by receiving Destroy request."))
         }
       }
       // remove slave locations from worker info

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -391,11 +391,13 @@ private[celeborn] class Worker(
     expiredShuffleKeys.asScala.foreach { shuffleKey =>
       partitionLocationInfo.getAllMasterLocations(shuffleKey).asScala.foreach { partition =>
         val fileWriter = partition.asInstanceOf[WorkingPartition].getFileWriter
-        fileWriter.destroy(new IOException(s"FileWriter ${fileWriter} expired"))
+        fileWriter.destroy(new IOException(
+          s"Destroy FileWriter ${fileWriter} caused by shuffle ${shuffleKey} expired."))
       }
       partitionLocationInfo.getAllSlaveLocations(shuffleKey).asScala.foreach { partition =>
         val fileWriter = partition.asInstanceOf[WorkingPartition].getFileWriter
-        fileWriter.destroy(new IOException(s"FileWriter ${fileWriter} expired"))
+        fileWriter.destroy(new IOException(
+          s"Destroy FileWriter ${fileWriter} caused by shuffle ${shuffleKey} expired."))
       }
       partitionLocationInfo.removeMasterPartitions(shuffleKey)
       partitionLocationInfo.removeSlavePartitions(shuffleKey)

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitor.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitor.scala
@@ -19,7 +19,6 @@ package org.apache.celeborn.service.deploy.worker.storage
 
 import java.io._
 import java.nio.charset.Charset
-import java.nio.file.FileAlreadyExistsException
 import java.util
 import java.util.{Set => jSet}
 import java.util.concurrent.{ConcurrentHashMap, TimeUnit}

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -143,12 +143,6 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
       if (operator != null) {
         operator.shutdown()
       }
-    } else if (diskStatus == DiskStatus.READ_OR_WRITE_FAILURE) {
-      logInfo(s"Face read or write failure, destroy all file writers under ${mountPoint}")
-      // TODO:
-      //  1. do we need to wait rest file workers to finish their work(like close()?) or just immediately destroy them
-      //  because there is existed write error
-      workingDirWriters.get(mountPoint).asScala.foreach(_.destroy)
     }
   }
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -143,6 +143,12 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
       if (operator != null) {
         operator.shutdown()
       }
+    } else if (diskStatus == DiskStatus.READ_OR_WRITE_FAILURE) {
+      logInfo(s"Face read or write failure, destroy all file writers under ${mountPoint}")
+      // TODO:
+      //  1. do we need to wait rest file workers to finish their work(like close()?) or just immediately destroy them
+      //  because there is existed write error
+      workingDirWriters.get(mountPoint).asScala.foreach(_.destroy)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
When trigger notifyError, StorageManager will destroy corresponding file writers

### Why are the changes needed?
To destroy the related fileWriters when their related flusher(they bind with same mount) faces I/O Exception then trigger                     `processIOException(e, DiskStatus.READ_OR_WRITE_FAILURE)`

### What are the items that need reviewer attention?
1. do we need to wait rest file workers to finish their work(like close()?) or just immediately destroy them because there is existed write error of disk

### Related issues.
#879 

### Related pull requests.


### How was this patch tested?


/cc @AngersZhuuuu 

/assign @main-reviewer
