### PR TITLE
Fix MasterNode RPC endpoint info

### DIFF
--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterNode.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterNode.scala
@@ -32,11 +32,11 @@ case class MasterNode(
 
   def ratisPort: Int = ratisAddr.getPort
 
-  def rpcPort: Int = ratisAddr.getPort
+  def rpcPort: Int = rpcAddr.getPort
 
   def ratisEndpoint: String = ratisAddr.getHostName + ":" + ratisAddr.getPort
 
-  def rpcEndpoint: String = ratisAddr.getHostName + ":" + rpcPort
+  def rpcEndpoint: String = rpcAddr.getHostName + ":" + rpcPort
 }
 
 object MasterNode {
@@ -69,8 +69,8 @@ object MasterNode {
       this
     }
 
-    def setRatisPort(port: Int): this.type = {
-      this.ratisPort = port
+    def setRatisPort(ratisPort: Int): this.type = {
+      this.ratisPort = ratisPort
       this
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix MasterNode RPC endpoint info

### Why are the changes needed?

```
2022-11-03 20:11:44 [WARN] [dispatcher-event-loop-4] org.apache.celeborn.common.haclient.RssHARetryClient#256 - Connect to celeborn-master-2.celeborn-master-svc.spark.svc.cluster.local:9872 failed.
org.apache.celeborn.common.rpc.RpcTimeoutException: Futures timed out after [30000 milliseconds]. This timeout is controlled by celeborn.rpc.lookupTimeout
	at org.apache.celeborn.common.rpc.RpcTimeout.org$apache$celeborn$common$rpc$RpcTimeout$$createRpcTimeoutException(RpcTimeout.scala:46) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.4.jar:0.2.0.4]
	at org.apache.celeborn.common.rpc.RpcTimeout$$anonfun$addMessageIfTimeout$1.applyOrElse(RpcTimeout.scala:61) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.4.jar:0.2.0.4]
	at org.apache.celeborn.common.rpc.RpcTimeout$$anonfun$addMessageIfTimeout$1.applyOrElse(RpcTimeout.scala:57) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.4.jar:0.2.0.4]
	at scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:38) ~[scala-library-2.12.15.jar:?]
	at org.apache.celeborn.common.rpc.RpcTimeout.awaitResult(RpcTimeout.scala:75) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.4.jar:0.2.0.4]
	at org.apache.celeborn.common.rpc.RpcEnv.setupEndpointRefByURI(RpcEnv.scala:96) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.4.jar:0.2.0.4]
	at org.apache.celeborn.common.rpc.RpcEnv.setupEndpointRef(RpcEnv.scala:104) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.4.jar:0.2.0.4]
	at org.apache.celeborn.common.haclient.RssHARetryClient.setupEndpointRef(RssHARetryClient.java:251) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.4.jar:0.2.0.4]
	at org.apache.celeborn.common.haclient.RssHARetryClient.setRpcEndpointRef(RssHARetryClient.java:191) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.4.jar:0.2.0.4]
	at org.apache.celeborn.common.haclient.RssHARetryClient.shouldRetry(RssHARetryClient.java:174) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.4.jar:0.2.0.4]
	at org.apache.celeborn.common.haclient.RssHARetryClient.sendMessageInner(RssHARetryClient.java:153) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.4.jar:0.2.0.4]
	at org.apache.celeborn.common.haclient.RssHARetryClient.askSync(RssHARetryClient.java:118) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.4.jar:0.2.0.4]
	at org.apache.celeborn.client.LifecycleManager.requestGetBlacklist(LifecycleManager.scala:1572) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.4.jar:0.2.0.4]
	at org.apache.celeborn.client.LifecycleManager.org$apache$celeborn$client$LifecycleManager$$handleGetBlacklist(LifecycleManager.scala:1454) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.4.jar:0.2.0.4]
	at org.apache.celeborn.client.LifecycleManager$$anonfun$receive$1.applyOrElse(LifecycleManager.scala:292) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.4.jar:0.2.0.4]
	at org.apache.celeborn.common.rpc.netty.Inbox.$anonfun$process$1(Inbox.scala:129) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.4.jar:0.2.0.4]
	at org.apache.celeborn.common.rpc.netty.Inbox.safelyCall(Inbox.scala:222) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.4.jar:0.2.0.4]
	at org.apache.celeborn.common.rpc.netty.Inbox.process(Inbox.scala:110) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.4.jar:0.2.0.4]
	at org.apache.celeborn.common.rpc.netty.Dispatcher$MessageLoop.run(Dispatcher.scala:229) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.4.jar:0.2.0.4]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_345]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_345]
	at java.lang.Thread.run(Thread.java:750) ~[?:1.8.0_345]
Caused by: java.util.concurrent.TimeoutException: Futures timed out after [30000 milliseconds]
	at scala.concurrent.impl.Promise$DefaultPromise.ready(Promise.scala:259) ~[scala-library-2.12.15.jar:?]
	at scala.concurrent.impl.Promise$DefaultPromise.result(Promise.scala:263) ~[scala-library-2.12.15.jar:?]
	at org.apache.celeborn.common.util.ThreadUtils$.awaitResult(ThreadUtils.scala:227) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.4.jar:0.2.0.4]
	at org.apache.celeborn.common.rpc.RpcTimeout.awaitResult(RpcTimeout.scala:74) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.4.jar:0.2.0.4]
	... 17 more
```

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
