### PR TITLE
Exclude unused files from Spark shaded client

### DIFF
--- a/client-spark/spark-3-shaded/pom.xml
+++ b/client-spark/spark-3-shaded/pom.xml
@@ -112,8 +112,8 @@
                 <delete file="${project.build.directory}/unpacked/META-INF/native/libnetty_transport_native_kqueue_aarch_64.jnilib"></delete>
                 <delete file="${project.build.directory}/unpacked/META-INF/native/libnetty_resolver_dns_native_macos_aarch_64.jnilib"></delete>
                 <delete file="${project.build.directory}/unpacked/META-INF/native/libnetty_resolver_dns_native_macos_x86_64.jnilib"></delete>
-                <echo message="deleting META-INF/native-image folder"/>
-                <delete dir="${project.build.directory}/unpacked/META-INF/native-image"/>
+                <echo message="deleting META-INF/native-image folder"></echo>
+                <delete dir="${project.build.directory}/unpacked/META-INF/native-image"></delete>
                 <echo message="repackaging netty jar"></echo>
                 <jar basedir="${project.build.directory}/unpacked" destfile="${project.build.directory}/${artifactId}-${version}.jar"></jar>
               </target>

--- a/client-spark/spark-3-shaded/pom.xml
+++ b/client-spark/spark-3-shaded/pom.xml
@@ -73,6 +73,7 @@
             <filter>
               <artifact>*:*</artifact>
               <excludes>
+                <exclude>**/*.proto</exclude>
                 <exclude>META-INF/*.SF</exclude>
                 <exclude>META-INF/*.DSA</exclude>
                 <exclude>META-INF/*.RSA</exclude>
@@ -111,6 +112,8 @@
                 <delete file="${project.build.directory}/unpacked/META-INF/native/libnetty_transport_native_kqueue_aarch_64.jnilib"></delete>
                 <delete file="${project.build.directory}/unpacked/META-INF/native/libnetty_resolver_dns_native_macos_aarch_64.jnilib"></delete>
                 <delete file="${project.build.directory}/unpacked/META-INF/native/libnetty_resolver_dns_native_macos_x86_64.jnilib"></delete>
+                <echo message="deleting META-INF/native-image folder"/>
+                <delete dir="${project.build.directory}/unpacked/META-INF/native-image"/>
                 <echo message="repackaging netty jar"></echo>
                 <jar basedir="${project.build.directory}/unpacked" destfile="${project.build.directory}/${artifactId}-${version}.jar"></jar>
               </target>


### PR DESCRIPTION
# [BUG]/[FEATURE] title

### What changes were proposed in this pull request?

Exclude unused files from Spark shaded client

### Why are the changes needed?

We does not relocate and use proto files and native-image files, so just exclude them from the shaded jar.

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
